### PR TITLE
Make Slider dumb, provide a wrapper

### DIFF
--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -1,6 +1,7 @@
-import React, { useRef, useState } from 'react';
+/* Libraries */
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import * as theme from './../theme/';
 
 const Thumb = styled.input.attrs({
@@ -96,29 +97,25 @@ const Input = styled.div`
   position: relative;
 `;
 
-const Slider = (props) => {
-  const { min = 0, max = 0 } = props;
-  const [value, setValue] = useState(props.value || 0);
+const Slider = ({
+  value,
+  min = 0,
+  max = 0,
+  largeStep,
+  onKeyDown,
+  onChange,
+  ...props,
+}) => {
   const percentage = ((value - min) * 100) / (max - min || 100);
-
-  const handleChange = (event) => {
-    const newValue = event.target.value;
-    setValue(newValue);
-    if (props.onChange) {
-      props.onChange(event);
-    }
-  };
-
+  const handleChange = (event) => onChange(parseInt(event.target.value, 10));
   const handleKeyDown = (event) => {
-    if (props.onKeyDown) {
-      props.onKeyDown(event);
-    }
+    onKeyDown(event);
 
     if (event.shiftKey) {
       if (event.keyCode === 37) {
-        setValue(Math.max(props.min, parseInt(value, 10) - props.largeStep));
+        onChange(Math.max(min, parseInt(value, 10) - largeStep));
       } else if (event.keyCode === 39) {
-        setValue(Math.min(props.max, parseInt(value, 10) + props.largeStep));
+        onChange(Math.min(max, parseInt(value, 10) + largeStep));
       }
 
       event.preventDefault();
@@ -149,10 +146,17 @@ Slider.propTypes = {
 }
 
 Slider.defaultProps = {
-  step: "1",
+  step: '1',
   largeStep: 10,
   min: 0,
   max: 100,
+  onChange: () => undefined,
+  onKeyDown: () => undefined,
+};
+
+export const SliderWrapper = ({ value: initialValue }) => {
+  const [value, setValue] = useState(initialValue);
+  return <Slider value={value} onChange={setValue} />;
 };
 
 export default Slider;

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ import MenuItem from './components/MenuItem';
 import MenuItemButton from './components/MenuItemButton';
 import MenuItemLink from './components/MenuItemLink';
 import Section from './components/Section';
-import Slider from './components/Slider';
+import Slider, { SliderWrapper } from './components/Slider';
 import Select from './components/Select';
 import Switch from './components/Switch';
 import Text from './components/Text';
@@ -1291,7 +1291,7 @@ export default class extends Component {
               </Box>
             </div>
             <div>
-              <Slider value={2} />
+              <SliderWrapper value={2} />
             </div>
             <div>
               <Switch />


### PR DESCRIPTION
The Slider component still exports the same API -- but it has been updated to be a dumb component. Internally, the demo page uses a `SliderWrapper` component which isn't exported to provide a place to hold state for the demo Slider component.