### PR TITLE
feat(dialog): Split DialogProvider from DialogRoot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radix-ds",
-  "version": "0.4.10",
+  "version": "0.5.0-0",
   "description": "Design system and component libray for Modulz.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -2,7 +2,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 /* Store */
-import { DialogContext, Actions as DialogActions } from './DialogRoot';
+import { DialogContext, Actions as DialogActions } from './DialogProvider';
 
 const Dialog = ({
   children,

--- a/src/components/DialogProvider.js
+++ b/src/components/DialogProvider.js
@@ -1,0 +1,55 @@
+/* Libaries */
+import React, { createContext, useReducer } from 'react';
+
+/* Component */
+const DialogContext = createContext();
+
+const initialState = {
+  dialogs: [],
+  closing: false,
+};
+
+const Actions = {
+  OPEN: 'OPEN',
+  BEGIN_CLOSING: 'BEGIN_CLOSING',
+  CLOSE: 'CLOSE',
+};
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case Actions.OPEN:
+      return {
+        ...state,
+        closing: false,
+        dialogs: [action.dialog, ...state.dialogs],
+      };
+    case Actions.BEGIN_CLOSING:
+      return {
+        ...state,
+        closing: true,
+      };
+    case Actions.CLOSE:
+      return {
+        ...state,
+        closing: false,
+        dialogs: state.dialogs.filter((dialog) => dialog !== action.dialog),
+      };
+    default:
+      return state;
+  }
+}
+
+const DialogProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return (
+    <DialogContext.Provider value={{ state, dispatch }}>
+      {children}
+    </DialogContext.Provider>
+  );
+};
+
+export {
+  DialogProvider,
+  DialogContext,
+  Actions,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,9 @@ import Textarea from './components/Textarea';
 import Flexbox from './components/Flexbox';
 import Heading from './components/Heading';
 import Overlay from './components/Overlay';
+import { DialogProvider } from './components/DialogProvider';
 import Dialog from './components/Dialog';
-import { DialogRoot } from './components/DialogRoot';
+import DialogRoot from './components/DialogRoot';
 import Title from './components/Title';
 import Status from './components/Status';
 import Image from './components/Image';
@@ -71,8 +72,9 @@ export Heading from './components/Heading';
 export Image from './components/Image';
 export Input from './components/Input';
 export Overlay from './components/Overlay';
+export { DialogProvider } from './components/DialogProvider';
 export Dialog from './components/Dialog';
-export { DialogRoot } from './components/DialogRoot';
+export DialogRoot from './components/DialogRoot';
 export LinesButton from './components/LinesButton';
 export Link from './components/Link';
 export List from './components/List';
@@ -109,6 +111,10 @@ export GhostInput from './components/GhostInput';
 import * as Theme from './theme';
 export { Theme };
 
+const Providers = ({children}) => (
+  <DialogProvider>{children}</DialogProvider>
+)
+
 export default class extends Component {
   render() {
     // const demoDialog = ({ close }) => (
@@ -136,7 +142,7 @@ export default class extends Component {
     //   </Flexbox>
     // );
 
-    return <DialogRoot>
+    return <Providers>
       <Tooltip />
       <Alert gray>
         <Container size1>
@@ -3640,6 +3646,7 @@ export default class extends Component {
         </Container>
       </Box> */}
 
-    </DialogRoot>
+    <DialogRoot />
+    </Providers>
   }
 }


### PR DESCRIPTION
# Objective

To control the z-index of DialogRoot in context to an App without jumping through hoops, but to also account for future requirements.

## Changes

* DialogProvider is now required at the top of a React tree.
* Added an optional to render-prop to DialogRoot to override the Overlay

## Example

```js
import { DialogProvider, DialogRoot, Dialog, Overlay } from 'radix-ds'

const App () => (
  <DialogProvider>

    {/* Dialog can be used anywhere in this React tree, nothing new. */}
  
    <DialogRoot>{
      ({ active, onClick }) =>
        <Overlay active={active} onClick={onClick} style={{ zIndex: 99999 }} />
    }</DialogRoot>

  </DialogProvider>
)
```