### PR TITLE
Add `appearance: none` to Input Component

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -4,6 +4,7 @@ import * as theme from './../theme/';
 const Input = styled.input.attrs({
   type: 'text',
 })`
+  appearance: none;
   background-color: transparent;
   border: none;
   border-radius: 0;


### PR DESCRIPTION
Fixes `box-shadow` issue on iOS