### PR TITLE
fix: react & react-dom as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,19 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "react": "^16.8.1",
-    "react-dom": "^16.8.1",
     "styled-components": "^4.0.3"
+  },
+  "peerDependencies": {
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1"
   },
   "devDependencies": {
     "babel-plugin-styled-components": "^1.8.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "nwb": "^0.23.0",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "sinon": "^7.2.3"
   },
   "author": "Colm Tuite",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "styled-components": "^4.0.3"
   },
   "peerDependencies": {
-    "react": "^16.8.1",
-    "react-dom": "^16.8.1"
+    "react": "^16.8.1"
   },
   "devDependencies": {
     "babel-plugin-styled-components": "^1.8.0",


### PR DESCRIPTION
Make `react` & `react-dom` `peerDependencies`.

Otherwise when using `radix-ds` in a project you could potential have multiple version of `react` & `react-dom`.