### PR TITLE
Enable changelogs via lerna

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,38 @@
 > WIP
 
-# Radix Monorepo
+# Radix
 
 This repository is a [monorepo](https://github.com/babel/babel/blob/master/doc/design/monorepo.md) powered by [Lerna](https://github.com/lerna/lerna) and [yarn workspaces](https://yarnpkg.com/lang/en/docs/cli/workspaces/).
 
-### Develop
+## Contributing
 
-#### Install dependencies
+There are many ways to contribute to the Radix and it's packages. Please first [create an issue](https://github.com/modulz/radix/issues/new) with your proposal, and from there we can start a conversation.
 
-```sh
-yarn
+#### Getting Started
+
+Bootstrap the repo by simply running:
+
+```shell
+yarn             # Installs dependencies and links packages
+yarn start       # Develop Radix & it's Website
 ```
 
-#### Run website + Radix
+**Other Packages**
 
-```sh
-yarn start
+Check the `readme.md` of other packages, like `@modulz/radix-icons`, to get more details on contributing.
+
+#### Publishing
+
+We use `lerna publish` for managing the versions of packages in the monorepo. Since we also use [conventional-commits](https://www.conventionalcommits.org), changelogs will be generated automatically.
+
+Once all commits have been made, from the root of the monorepo simply run:
+
+```shell
+yarn release         # prompts modified packages, generates changelogs and publishes to npm
+yarn release:github  # does same as above, but also generates a github release
 ```
 
-### Build & Release
-
-#### Build
-
-```sh
-yarn build
-```
-
-#### Release
-
-```sh
-yarn release
-```
+> _Please [follow these instructions](https://github.com/lerna/lerna/tree/master/commands/version#--github-release) by Lerna to authenticate for Github Releases._
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "yarn radix:build",
     "start": "npm-run-all --parallel radix website",
     "website": "lerna exec --scope website -- yarn start",
     "website:build": "lerna exec --scope website -- yarn build",
@@ -16,9 +15,10 @@
     "prettier": "prettier './**/*.{js,jsx,ts,tsx,json,yml,yaml,css,md}' --write",
     "lint": "eslint './packages/**/*.{js,jsx,ts,tsx}'",
     "clean": "npm run clean-logs && npm run clean-modules",
-    "clean-logs": "rimraf ./packages/*/npm-debug* && rimraf ./*-debug*",
+    "clean-logs": "rimraf ./packages/*/*-debug* && rimraf ./*-debug*",
     "clean-modules": "rimraf ./packages/*/node_modules/ && rimraf ./node_modules/",
-    "release": "yarn radix:build && lerna publish"
+    "release": "lerna publish --conventional-commits",
+    "release:github": "lerna publish --github-release --conventional-commits"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",

--- a/packages/radix-icons/package.json
+++ b/packages/radix-icons/package.json
@@ -19,7 +19,7 @@
     "generate-src": "generate-icon-lib --file=LLggMY9IV61CYkCSI7LFFUOY",
     "build": "rimraf dist && tsdx build --format es,cjs --entry src/index.tsx",
     "watch": "rimraf dist && tsdx watch --format es,cjs --entry src/index.tsx",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
     "react": "^16.x",

--- a/packages/radix/package.json
+++ b/packages/radix/package.json
@@ -18,7 +18,8 @@
     "storybook": "start-storybook -p 9009 --ci",
     "build-storybook": "build-storybook",
     "build": "rollup -c",
-    "watch": "rollup -cw"
+    "watch": "rollup -cw",
+    "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
     "react": "^16.8.6",


### PR DESCRIPTION
Ello'! 👋

So lerna still handles changelog stuff internally, which is gggreat. The changes in this PR **haven't been tested**, and are instead a kickstart for you to get across the things necessary to automatically create changelogs for Radix. It's well worth getting across IMO - let me know if you're holding off on this kind of stuff though.

I've also updated the top-level readme so that folks in the team know how to release new versions without realtime-handholding.

---

### Notes

* Options passed to [`lerna publish`](https://github.com/lerna/lerna/tree/master/commands/publish) are also passed to [`lerna version`](https://github.com/lerna/lerna/tree/master/commands/version)
* The `--github-release` is pretty cool, but I personally have never used it... keen to try?
* I've removed the `postinstall` hooks because it was slowing down my local dev
* I've added prepublishOnly hooks to radix and radix-icons so that `yarn release` will fer-sure have latest dists