### PR TITLE
refactor(radix): update size variants

### DIFF
--- a/packages/radix/src/components/Badge.story.tsx
+++ b/packages/radix/src/components/Badge.story.tsx
@@ -7,14 +7,14 @@ storiesOf('Components|Badge', module).add('default', () => (
   <>
     <Box mb="4">
       <Badge mr="4">Badge</Badge>
-      <Badge size="large">Badge</Badge>
+      <Badge size={0}>Badge</Badge>
     </Box>
 
     <Box mb="4">
       <Badge variant="blue" mr="4">
         Blue
       </Badge>
-      <Badge variant="blue" size="large" mr="4">
+      <Badge variant="blue" size={1} mr="4">
         Blue
       </Badge>
     </Box>
@@ -23,7 +23,7 @@ storiesOf('Components|Badge', module).add('default', () => (
       <Badge variant="green" mr="4">
         Green
       </Badge>
-      <Badge variant="green" size="large">
+      <Badge variant="green" size={1}>
         Green
       </Badge>
     </Box>
@@ -32,7 +32,7 @@ storiesOf('Components|Badge', module).add('default', () => (
       <Badge variant="red" mr="4">
         Red
       </Badge>
-      <Badge variant="red" size="large">
+      <Badge variant="red" size={1}>
         Red
       </Badge>
     </Box>
@@ -41,7 +41,7 @@ storiesOf('Components|Badge', module).add('default', () => (
       <Badge variant="yellow" mr="4">
         Yellow
       </Badge>
-      <Badge variant="yellow" size="large">
+      <Badge variant="yellow" size={1}>
         Yellow
       </Badge>
     </Box>

--- a/packages/radix/src/components/Badge.tsx
+++ b/packages/radix/src/components/Badge.tsx
@@ -3,7 +3,7 @@ import { margin, MarginProps, variant, Prop } from '@modulz/radix-system';
 import css from '@styled-system/css';
 
 type Variants = 'gray' | 'blue' | 'green' | 'red' | 'yellow';
-type Sizes = 'normal' | 'large';
+type Sizes = 0 | 1;
 
 type BadgeProps = MarginProps & {
   variant?: Prop<Variants>;
@@ -54,13 +54,13 @@ export const Badge = styled('span')<BadgeProps>(
   }),
   variant({
     size: {
-      normal: {
+      0: {
         fontSize: 0,
         height: 3,
         minWidth: 5,
         paddingX: 2,
       },
-      large: {
+      1: {
         fontSize: 1,
         height: 5,
         minWidth: 6,
@@ -74,5 +74,5 @@ export const Badge = styled('span')<BadgeProps>(
 
 Badge.defaultProps = {
   variant: 'gray',
-  size: 'normal',
+  size: 0,
 };

--- a/packages/radix/src/components/Button.story.tsx
+++ b/packages/radix/src/components/Button.story.tsx
@@ -7,14 +7,14 @@ storiesOf('Components|Button', module).add('default', () => (
   <>
     <Box mb="4">
       <Button mr="4">Button</Button>
-      <Button size="large">Button</Button>
+      <Button size={1}>Button</Button>
     </Box>
 
     <Box mb="4">
       <Button variant="blue" mr="4">
         Blue
       </Button>
-      <Button variant="blue" size="large" mr="4">
+      <Button variant="blue" size={1} mr="4">
         Blue
       </Button>
     </Box>
@@ -23,7 +23,7 @@ storiesOf('Components|Button', module).add('default', () => (
       <Button variant="green" mr="4">
         Green
       </Button>
-      <Button variant="green" size="large">
+      <Button variant="green" size={1}>
         Green
       </Button>
     </Box>
@@ -32,7 +32,7 @@ storiesOf('Components|Button', module).add('default', () => (
       <Button variant="red" mr="4">
         Red
       </Button>
-      <Button variant="red" size="large">
+      <Button variant="red" size={1}>
         Red
       </Button>
     </Box>
@@ -41,7 +41,7 @@ storiesOf('Components|Button', module).add('default', () => (
       <Button variant="active" mr="4">
         Active
       </Button>
-      <Button variant="active" size="large">
+      <Button variant="active" size={1}>
         Active
       </Button>
     </Box>
@@ -50,7 +50,7 @@ storiesOf('Components|Button', module).add('default', () => (
       <Button disabled={true} mr="4">
         Disabled
       </Button>
-      <Button disabled={true} size="large">
+      <Button disabled={true} size={1}>
         Disabled
       </Button>
     </Box>
@@ -59,14 +59,14 @@ storiesOf('Components|Button', module).add('default', () => (
       <Button variant="waiting" mr="4">
         Waiting
       </Button>
-      <Button variant="waiting" size="large">
+      <Button variant="waiting" size={1}>
         Waiting
       </Button>
     </Box>
 
     <Box mb="4">
       <Button variant="blue" mr="4">
-        <Box as="span" mr="2">
+        <Box as="span" mr={2}>
           <svg
             width="18"
             height="18"
@@ -82,8 +82,8 @@ storiesOf('Components|Button', module).add('default', () => (
         </Box>
         Follow
       </Button>
-      <Button variant="blue" size="large">
-        <Box as="span" mr="2">
+      <Button variant="blue" size={1}>
+        <Box as="span" mr={2}>
           <svg
             width="25"
             height="25"

--- a/packages/radix/src/components/Button.tsx
+++ b/packages/radix/src/components/Button.tsx
@@ -10,7 +10,7 @@ const waitingAnimation = (props: any) => keyframes`
 `;
 
 type Variants = 'gray' | 'blue' | 'green' | 'red' | 'active' | 'waiting';
-type Sizes = 'normal' | 'large';
+type Sizes = 0 | 1;
 
 type ButtonProps = MarginProps & {
   variant?: Prop<Variants>;
@@ -125,13 +125,13 @@ export const Button = styled('button')<ButtonProps>(
   }),
   variant({
     size: {
-      normal: {
+      0: {
         fontSize: 2,
         paddingX: 2,
         height: 5,
         minWidth: 5,
       },
-      large: {
+      1: {
         fontSize: 3,
         paddingX: 3,
         height: 6,
@@ -161,7 +161,7 @@ export const Button = styled('button')<ButtonProps>(
             transparent 66%
           )`,
         backgroundSize:
-          size === 'large'
+          size === 1
             ? `${themeGet('space.9')({ theme })} ${themeGet('space.6')({
                 theme,
               })}`
@@ -185,5 +185,5 @@ export const Button = styled('button')<ButtonProps>(
 
 Button.defaultProps = {
   variant: 'gray',
-  size: 'normal',
+  size: 0,
 };

--- a/packages/radix/src/components/GhostButton.story.tsx
+++ b/packages/radix/src/components/GhostButton.story.tsx
@@ -61,19 +61,19 @@ storiesOf('Components|GhostButton', module).add('default', () => (
     </Box>
 
     <Box mb="4">
-      <GhostButton size="large" mr="4">
+      <GhostButton size={1} mr="4">
         {Bookmark}
       </GhostButton>
-      <GhostButton size="large" disabled mr="4">
+      <GhostButton size={1} disabled mr="4">
         {Bookmark}
       </GhostButton>
-      <GhostButton size="large" mr="4" px={2}>
+      <GhostButton size={1} mr="4" px={2}>
         <Box mr={1}>{Bookmark}</Box> Bookmark
       </GhostButton>
-      <GhostButton size="large" variant="active" mr="4">
+      <GhostButton size={1} variant="active" mr="4">
         {Bookmark}
       </GhostButton>
-      <GhostButton size="large" mr="4" px={2}>
+      <GhostButton size={1} mr="4" px={2}>
         Bookmark
       </GhostButton>
     </Box>

--- a/packages/radix/src/components/GhostButton.tsx
+++ b/packages/radix/src/components/GhostButton.tsx
@@ -4,7 +4,7 @@ import { margin, MarginProps, padding, PaddingProps, variant, compose } from '@m
 import themeGet from '@styled-system/theme-get';
 
 type Variants = 'normal' | 'active';
-type Sizes = 'normal' | 'large';
+type Sizes = 0 | 1;
 type GhostButtonProps = MarginProps &
   PaddingProps & {
     variant?: Variants;
@@ -80,13 +80,13 @@ export const GhostButton = styled.button<GhostButtonProps>(
     }),
   variant({
     size: {
-      normal: {
+      0: {
         fontSize: 1,
         height: 5,
         lineHeight: 1,
         minWidth: 5,
       },
-      large: {
+      1: {
         fontSize: 3,
         height: 6,
         lineHeight: 2,
@@ -99,5 +99,5 @@ export const GhostButton = styled.button<GhostButtonProps>(
 
 GhostButton.defaultProps = {
   variant: 'normal',
-  size: 'normal',
+  size: 0,
 };

--- a/packages/radix/src/components/Input.story.tsx
+++ b/packages/radix/src/components/Input.story.tsx
@@ -29,11 +29,11 @@ storiesOf('Components|Input', module).add('default', () => (
     </Box>
 
     <Box mb="4">
-      <Input size="large" placeholder="Your email" />
+      <Input size={1} placeholder="Your email" />
     </Box>
 
     <Box mb="4" position="relative">
-      <Input size="large" placeholder="e.g. joe@example.com" type="email" paddingLeft={6} />
+      <Input size={1} placeholder="e.g. joe@example.com" type="email" paddingLeft={6} />
 
       <Box
         position="absolute"
@@ -54,7 +54,7 @@ storiesOf('Components|Input', module).add('default', () => (
     </Box>
 
     <Box mb="4">
-      <Input variant="ghost" size="large" placeholder="Ghost input" />
+      <Input variant="ghost" size={1} placeholder="Ghost input" />
     </Box>
 
     <Box mb="4">

--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -19,7 +19,7 @@ import {
 } from '@modulz/radix-system';
 
 type VariantProps = 'normal' | 'ghost' | 'fade';
-type SizeProps = 'normal' | 'large';
+type SizeProps = 0 | 1;
 
 // TODO: Fix `size` typing
 export type InputProps = TextColorProps &
@@ -76,8 +76,8 @@ export const Input = styled('input')<InputProps>(
   }),
   variant({
     size: {
-      normal: { fontSize: 2, height: 5, lineHeight: 1 },
-      large: { fontSize: 3, height: 6, lineHeight: 3 },
+      0: { fontSize: 2, height: 5, lineHeight: 1 },
+      1: { fontSize: 3, height: 6, lineHeight: 3 },
     },
   }),
   variant({
@@ -103,4 +103,4 @@ export const Input = styled('input')<InputProps>(
   styleProps
 );
 
-Input.defaultProps = { type: 'text', variant: 'normal', size: 'normal' };
+Input.defaultProps = { type: 'text', variant: 'normal', size: 0 };

--- a/packages/radix/src/components/Textarea.story.tsx
+++ b/packages/radix/src/components/Textarea.story.tsx
@@ -10,7 +10,7 @@ storiesOf('Components|Textara', module).add('default', () => (
     </Box>
 
     <Box mb="4">
-      <Textarea size="large" placeholder="Your email" />
+      <Textarea size={1} placeholder="Your email" />
     </Box>
 
     <Box mb="4">

--- a/packages/radix/src/components/Textarea.tsx
+++ b/packages/radix/src/components/Textarea.tsx
@@ -19,7 +19,7 @@ import {
 } from '@modulz/radix-system';
 
 type VariantProps = 'normal' | 'ghost' | 'fade';
-type SizeProps = 'normal' | 'large';
+type SizeProps = 0 | 1;
 
 // TODO: Fix `size` typing
 export type TextareaProps = TextColorProps &
@@ -77,8 +77,8 @@ export const Textarea = styled('textarea')<TextareaProps>(
   }),
   variant({
     size: {
-      normal: { fontSize: 2, height: 5, lineHeight: 1 },
-      large: { fontSize: 3, height: 6, lineHeight: 3 },
+      0: { fontSize: 2, height: 5, lineHeight: 1 },
+      1: { fontSize: 3, height: 6, lineHeight: 3 },
     },
   }),
   variant({
@@ -104,4 +104,4 @@ export const Textarea = styled('textarea')<TextareaProps>(
   styleProps
 );
 
-Textarea.defaultProps = { variant: 'normal', size: 'normal' };
+Textarea.defaultProps = { variant: 'normal', size: 0 };

--- a/packages/website/src/docs/badge.mdx
+++ b/packages/website/src/docs/badge.mdx
@@ -21,7 +21,7 @@ component: Badge
 ```
 
 ```js live=true
-<Badge size="large">Badge</Badge>
+<Badge size={1}>Badge</Badge>
 ```
 
 ### System props
@@ -30,7 +30,7 @@ component: Badge
 
 ### Custom props
 
-| Name      | Type                                             | Default  | Description        |
-| :-------- | :----------------------------------------------- | :------: | :----------------- |
-| `variant` | 'gray' \| 'blue' \| 'green' \| 'red' \| 'yellow' |  `gray`  | Variant to display |
-| `size`    | 'normal' \| 'large'                              | `normal` | Size to display    |
+| Name      | Type                                             | Default | Description        |
+| :-------- | :----------------------------------------------- | :-----: | :----------------- |
+| `variant` | 'gray' \| 'blue' \| 'green' \| 'red' \| 'yellow' | `gray`  | Variant to display |
+| `size`    | 0 \| 1                                           |   `0`   | Size to display    |

--- a/packages/website/src/docs/button.mdx
+++ b/packages/website/src/docs/button.mdx
@@ -6,7 +6,9 @@ component: Button
 ```js live=true
 <Button>New project</Button>
 ```
+
 ### Color
+
 There are 4 color options to choose from.
 
 ```js live=true
@@ -22,42 +24,40 @@ There are 4 color options to choose from.
 ```
 
 ### Size
+
 There are 2 size options to choose from.
 
 ```js live=true
-<Button>
+<Button size={0}>
   Default
 </Button>
-<Button size="large" ml={6}>
+<Button size={1} ml={6}>
   Large
 </Button>
 ```
 
 ### Active
+
 When a button is active.
 
 ```js live=true
-<Button variant="active">
-  Add
-</Button>
+<Button variant="active">Add</Button>
 ```
 
 ### Waiting
+
 When the user is waiting for the server to respond.
 
 ```js live=true
-<Button variant="waiting">
-  Waiting
-</Button>
+<Button variant="waiting">Waiting</Button>
 ```
 
 ### Disabled
+
 For when your button is disabled.
 
 ```js live=true
-<Button disabled>
-  New project
-</Button>
+<Button disabled>New project</Button>
 ```
 
 ### System props
@@ -66,8 +66,8 @@ For when your button is disabled.
 
 ### Custom props
 
-| Name       | Type                                                          | Default  | Description          |
-| :--------- | :------------------------------------------------------------ | :------: | :------------------- |
-| `variant`  | 'gray' \| 'blue' \| 'green' \| 'red' \| 'active' \| 'waiting' |  `gray`  | Variant to display   |
-| `size`     | 'normal' \| 'large'                                           | `normal` | Size to display      |
-| `disabled` | Boolean                                                       | `false`  | Disables the element |
+| Name       | Type                                                          | Default | Description          |
+| :--------- | :------------------------------------------------------------ | :-----: | :------------------- |
+| `variant`  | 'gray' \| 'blue' \| 'green' \| 'red' \| 'active' \| 'waiting' | `gray`  | Variant to display   |
+| `size`     | 0 \| 1                                                        |   `0`   | Size to display      |
+| `disabled` | Boolean                                                       | `false` | Disables the element |

--- a/packages/website/src/docs/ghost-button.mdx
+++ b/packages/website/src/docs/ghost-button.mdx
@@ -18,15 +18,15 @@ component: GhostButton
 ```
 
 ```js live=true
-<GhostButton size="large">
+<GhostButton size={1}>
   <HamburgerIcon size="25" />
 </GhostButton>
 
-<GhostButton size="large" variant="active" ml={3}>
+<GhostButton size={1} variant="active" ml={3}>
   <HamburgerIcon size="25" />
 </GhostButton>
 
-<GhostButton size="large" disabled ml={3}>
+<GhostButton size={1} disabled ml={3}>
   <HamburgerIcon size="25" />
 </GhostButton>
 ```
@@ -40,5 +40,5 @@ component: GhostButton
 | Name       | Type                 | Default  | Description          |
 | :--------- | :------------------- | :------: | :------------------- |
 | `variant`  | 'normal' \| 'active' | `normal` | Variant to display   |
-| `size`     | 'normal' \|'large'   | `normal` | Size to display      |
+| `size`     | 0 \| 1               |   `0`    | Size to display      |
 | `disabled` | Boolean              | `false`  | Disables the element |

--- a/packages/website/src/docs/input.mdx
+++ b/packages/website/src/docs/input.mdx
@@ -8,7 +8,7 @@ component: Input
 ```
 
 ```js live=true
-<Input size="large" placeholder="Your e-mail address" />
+<Input size={1} placeholder="Your e-mail address" />
 ```
 
 ```js live=true
@@ -28,4 +28,4 @@ component: Input
 | Name      | Type                          | Default  | Description        |
 | :-------- | :---------------------------- | :------: | :----------------- |
 | `variant` | 'normal' \| 'ghost' \| 'fade' | `normal` | Variant to display |
-| `size`    | 'normal' \| 'large'           | `normal` | Size to display    |
+| `size`    | 0 \| 1                        |   `0`    | Size to display    |

--- a/packages/website/src/docs/textarea.mdx
+++ b/packages/website/src/docs/textarea.mdx
@@ -8,7 +8,7 @@ component: Textarea
 ```
 
 ```js live=true
-<Textarea size="large" placeholder="Leave your comment here" />
+<Textarea size={1} placeholder="Leave your comment here" />
 ```
 
 ### System props
@@ -17,7 +17,7 @@ component: Textarea
 
 ### Custom props
 
-| Name      | Type                | Default  | Description        |
-| :-------- | :------------------ | :------: | :----------------- |
-| `variant` | 'normal' \|'ghost'  | `normal` | Variant to display |
-| `size`    | 'normal' \| 'large' | `normal` | Size to display    |
+| Name      | Type               | Default  | Description        |
+| :-------- | :----------------- | :------: | :----------------- |
+| `variant` | 'normal' \|'ghost' | `normal` | Variant to display |
+| `size`    | 0 \| 1             |   `0`    | Size to display    |


### PR DESCRIPTION
Instead of using `normal` and `large`, I've changed them to be `0` and `1`.

I think this is more consistent throughout the codebase now and also it's a bit more abstract.

Still don't think it's the perfect solution, but a small improvement.

Keen to hear thoughts.
