### PR TITLE
chore(website): redirect from Netlify to Modulz domain

### DIFF
--- a/packages/website/_redirects
+++ b/packages/website/_redirects
@@ -1,0 +1,3 @@
+# Redirect default Netlify subdomain to primary domain
+https://modulz-radix.netlify.com/* https://radix.modulz.app/:splat 301!
+http://modulz-radix.netlify.com/* https://radix.modulz.app/:splat 301!


### PR DESCRIPTION
Right now you can access the Radix docs from https://modulz-radix.netlify.com and https://radix.modulz.app, is the same website served from two different URLs.

By adding the Netlify `_redirects` file with these two rules any url accessed from the Netlify domain will be redirected to the Modulz domain.

For example:

https://modulz-radix.netlify.com/docs/playground/ will be redirected to https://radix.modulz.app/docs/playground/

