### PR TITLE
Theme typing

### DIFF
--- a/packages/radix/src/theme.ts
+++ b/packages/radix/src/theme.ts
@@ -1,13 +1,17 @@
-// TODO: type Theme
-type Theme = any;
+type RadixBreakpoints<T> = Array<T> & {
+  small: 0;
+  medium: '38em';
+  large: '62em';
+  xlarge: '68em';
+};
 
-export const theme: Theme = {
-  breakpoints: ['38em', '62em', '68em', '110em'],
+export const theme = {
+  breakpoints: ['38em', '62em', '68em', '110em'] as RadixBreakpoints<any>,
   fonts: {
     normal:
-      'UntitledSans, apple-system, BlinkMacSystemFont, "Helvetica Neue", helvetica, arial, sans-serif',
+      'UntitledSans, -apple-system, BlinkMacSystemFont, "Helvetica Neue", helvetica, arial, sans-serif',
     medium:
-      'UntitledSans-Medium, apple-system, BlinkMacSystemFont, "Helvetica Neue", helvetica, arial, sans-serif',
+      'UntitledSans-Medium, -apple-system, BlinkMacSystemFont, "Helvetica Neue", helvetica, arial, sans-serif',
     mono: 'OperatorMono-Book, Consolas, "Liberation Mono", Menlo, Courier, monospace',
   },
   fontSizes: [
@@ -26,7 +30,7 @@ export const theme: Theme = {
   space: ['0', '5px', '10px', '15px', '20px', '25px', '35px', '45px', '65px', '80px'],
   sizes: ['0', '5px', '10px', '15px', '20px', '25px', '35px', '45px', '65px', '80px'],
   lineHeights: ['20px', '25px', '30px', '35px', '40px', '45px', '50px', '55px', '60px'],
-  radii: [0, '3px', '5px', '10px'],
+  radii: ['0', '3px', '5px', '10px'],
   colors: {
     black: 'hsl(0, 0%, 0%)',
     blacks: [
@@ -105,7 +109,7 @@ export const theme: Theme = {
       'hsl(0, 100%, 10%)',
     ],
   },
-};
+} as const;
 
 // Breakpoint aliases
 // By adding the following aliases, repsonsive props


### PR DESCRIPTION
Ahoy!

I added theme typing for a better developer experience with Radix.

![ezgif-2-6ad5f0d7377a](https://user-images.githubusercontent.com/8441036/65255352-63abc900-db06-11e9-864f-a78d5447c01f.gif)

PS: I had to go out of my way a bit to type breakpoints as an array with property aliases, so it doesn't work as perfectly as with other properties. For example, you won't get an error for this `theme.breakpoints[10]`, although there's just 4 breakpoints. You still get typeahead support with the aliases though.

The question being are we using breakpoints as an array at all? If there're no hard reasons to keep it this way, I'd vouch for a simple object with `small, medium, large, xlarge` keys.
