### PR TITLE
Add a `showArrow` pop to Popover

### DIFF
--- a/packages/radix/src/components/Popover.story.tsx
+++ b/packages/radix/src/components/Popover.story.tsx
@@ -15,7 +15,7 @@ function PopoverExample() {
     <div
       style={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
     >
-      <GhostButton type="button" ref={buttonRef} onClick={() => setIsOpen(true)} size={1}>
+      <GhostButton type="button" ref={buttonRef} onClick={() => setIsOpen(true)}>
         <DotsVerticalIcon />
       </GhostButton>
 

--- a/packages/radix/src/components/Popover.tsx
+++ b/packages/radix/src/components/Popover.tsx
@@ -8,14 +8,16 @@ import { Card } from './Card';
 
 type PopoverProps = PopoverPrimitiveProps & {
   isOpen?: boolean;
+  showArrow?: boolean;
 };
 
-export const Popover = ({ children, ...props }: PopoverProps) => {
+export const Popover = ({ children, showArrow, ...props }: PopoverProps) => {
   return (
     <PopoverPrimitive
       side="bottom"
       align="center"
-      arrow={<Arrow width={20} height={10} />}
+      // TODO: Arrow `null` to not render an Arrow Component
+      arrow={showArrow ? <Arrow width={20} height={10} /> : <div />}
       {...props}
       getAnimationConfig={() => ({
         from: { opacity: 0 },

--- a/packages/website/src/docs/popover.mdx
+++ b/packages/website/src/docs/popover.mdx
@@ -62,6 +62,11 @@ description: An accessible Popover component that displays rich content as a res
       default: '0',
       description: 'The collision tolerance to apply',
     },
+    showArrow: {
+      type: 'Boolean',
+      default: 'false',
+      description: 'Whether the arrow should be visible or not',
+    },
   }}
 />
 


### PR DESCRIPTION
Change `Popover` to not render the arrow by default and introduce a `showArrow` prop