### PR TITLE
Input, Textarea and Select with box shadow border

### DIFF
--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -21,22 +21,18 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
             cursor: 'default',
             color: theme.colors.gray800,
             fontFamily: theme.fonts.normal,
-            border: '1px solid',
-            borderColor: theme.colors.gray300,
             borderRadius: theme.radii[1],
           },
           readOnly: {
-            borderColor: theme.colors.gray300,
             color: theme.colors.gray700,
           },
           disabled: {
-            borderColor: theme.colors.gray300,
+            backgroundColor: theme.colors.gray100,
             color: theme.colors.gray500,
             cursor: 'not-allowed',
           },
           focus: {
-            borderColor: theme.colors.blue500,
-            boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
+            boxShadow: `inset 0 0 0 1px ${theme.colors.blue500}, 0 0 0 1px ${theme.colors.blue500}`,
             cursor: 'text',
           },
         },
@@ -51,14 +47,13 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
           normal: {
             input: {
               normal: {
-                borderColor: theme.colors.gray300,
+                boxShadow: `inset 0 0 0 1px ${theme.colors.gray300}`,
               },
             },
           },
           ghost: {
             input: {
               normal: {
-                borderColor: 'transparent',
                 cursor: 'text',
               },
             },

--- a/packages/radix/src/components/Select.tsx
+++ b/packages/radix/src/components/Select.tsx
@@ -5,7 +5,6 @@ import {
   StyleConfig,
   SelectParts,
 } from 'mdlz-prmtz';
-import { transparentize } from 'polished';
 import merge from 'lodash.merge';
 import { theme } from '../theme';
 import { menuStyleConfig } from './Menu';
@@ -22,6 +21,7 @@ export const Select = (props: SelectProps) => {
 };
 
 Select.defaultProps = {
+  variant: 'normal',
   size: 0,
 };
 
@@ -29,25 +29,17 @@ const selectStyleConfigOverrides: StyleConfig<SelectParts> = {
   base: {
     button: {
       normal: {
-        backgroundColor: theme.colors.gray100,
         fontFamily: theme.fonts.normal,
         lineHeight: theme.lineHeights[0],
         borderRadius: theme.radii[1],
-        border: '1px solid',
-        borderColor: theme.colors.gray300,
         letterSpacing: '-0.01em',
         justifyContent: 'space-between',
         flexWrap: 'wrap', // allows the button to shrink
       },
-      hover: {
-        borderColor: theme.colors.gray400,
-      },
       focus: {
-        borderColor: theme.colors.blue500,
-        boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.blue500}, 0 0 0 1px ${theme.colors.blue500}`,
       },
       disabled: {
-        borderColor: theme.colors.gray300,
         color: theme.colors.gray500,
         cursor: 'not-allowed',
       },
@@ -69,21 +61,15 @@ const selectStyleConfigOverrides: StyleConfig<SelectParts> = {
       normal: {
         button: {
           normal: {
-            color: theme.colors.gray800,
+            backgroundColor: theme.colors.gray100,
+            boxShadow: `inset 0 0 0 1px ${theme.colors.gray300}`,
+          },
+          hover: {
+            boxShadow: `inset 0 0 0 1px ${theme.colors.gray400}`,
           },
         },
       },
-      ghost: {
-        button: {
-          normal: {
-            backgroundColor: 'transparent',
-            borderColor: 'transparent',
-          },
-          focus: {
-            borderColor: theme.colors.blue500,
-          },
-        },
-      },
+      ghost: {},
     },
     size: {
       0: {

--- a/packages/radix/src/components/Textarea.tsx
+++ b/packages/radix/src/components/Textarea.tsx
@@ -22,23 +22,19 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
               cursor: 'default',
               color: theme.colors.gray800,
               fontFamily: theme.fonts.normal,
-              border: '1px solid',
-              borderColor: theme.colors.gray300,
               borderRadius: theme.radii[1],
               minHeight: theme.sizes[9],
             },
             readOnly: {
-              borderColor: theme.colors.gray300,
               color: theme.colors.gray700,
             },
             disabled: {
-              borderColor: theme.colors.gray300,
+              backgroundColor: theme.colors.gray100,
               color: theme.colors.gray500,
               cursor: 'not-allowed',
             },
             focus: {
-              borderColor: theme.colors.blue500,
-              boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
+              boxShadow: `inset 0 0 0 1px ${theme.colors.blue500}, 0 0 0 1px ${theme.colors.blue500}`,
               cursor: 'text',
             },
           },
@@ -53,14 +49,13 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             normal: {
               textarea: {
                 normal: {
-                  borderColor: theme.colors.gray300,
+                  boxShadow: `inset 0 0 0 1px ${theme.colors.gray300}`,
                 },
               },
             },
             ghost: {
               textarea: {
                 normal: {
-                  borderColor: 'transparent',
                   cursor: 'text',
                 },
               },
@@ -72,9 +67,8 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
                 normal: {
                   fontSize: theme.fontSizes[1],
                   letterSpacing: '-0.01em',
-                  lineHeight: theme.lineHeights[2],
-                  paddingLeft: theme.space[1],
-                  paddingRight: theme.space[1],
+                  lineHeight: theme.lineHeights[1],
+                  padding: theme.space[1],
                 },
               },
             },
@@ -83,7 +77,9 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
                 normal: {
                   fontSize: theme.fontSizes[2],
                   letterSpacing: '-0.01em',
-                  lineHeight: theme.lineHeights[4],
+                  lineHeight: theme.lineHeights[1],
+                  paddingTop: theme.space[1],
+                  paddingBottom: theme.space[1],
                   paddingLeft: theme.space[2],
                   paddingRight: theme.space[2],
                 },


### PR DESCRIPTION
- Updated Input and Textarea to use `box-shadow` for borders
- Added light grey background for disabled Input and Textarea
- Updated Textarea layout. Compare [before](https://upload.vladmoroz.com/Screenshot%202019-12-17%20at%2013.34.11.png) and [after](https://upload.vladmoroz.com/Screenshot%202019-12-17%20at%2013.36.46.png).