### PR TITLE
Design updates to Input, Dialog, and Tooltip

### DIFF
--- a/packages/radix/src/components/Dialog.tsx
+++ b/packages/radix/src/components/Dialog.tsx
@@ -11,7 +11,7 @@ export const Dialog = (props: DialogProps) => (
       base: {
         overlay: {
           normal: {
-            backgroundColor: 'hsla(0, 0%, 100%, .5)',
+            backgroundColor: 'hsla(0, 0%, 0%, 0.1)',
           },
         },
         wrapper: {

--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -66,9 +66,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 fontSize: theme.fontSizes[1],
                 letterSpacing: '-0.01em',
                 height: theme.sizes[5],
-                lineHeight: theme.lineHeights[2],
+                lineHeight: theme.lineHeights[0], // Yields nice text selection height in Safari
                 paddingLeft: theme.space[1],
-                paddingRight: theme.space[1],
+                paddingRight: 1, // Makes up for the inset box shadow so it doesn't overlap
               },
             },
           },
@@ -78,9 +78,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 fontSize: theme.fontSizes[2],
                 letterSpacing: '-0.01em',
                 height: theme.sizes[6],
-                lineHeight: theme.lineHeights[4],
+                lineHeight: theme.lineHeights[0], // Yields nice text selection height in Safari
                 paddingLeft: theme.space[2],
-                paddingRight: theme.space[2],
+                paddingRight: 1, // Makes up for the inset box shadow so it doesn't overlap
               },
             },
           },

--- a/packages/radix/src/components/Tooltip.tsx
+++ b/packages/radix/src/components/Tooltip.tsx
@@ -15,9 +15,9 @@ export const Tooltip = (props: TooltipProps) => (
           normal: {
             backgroundColor: theme.colors.gray800,
             paddingTop: 0,
-            paddingRight: theme.space[1],
+            paddingRight: theme.space[2],
             paddingBottom: 0,
-            paddingLeft: theme.space[1],
+            paddingLeft: theme.space[2],
             lineHeight: theme.lineHeights[2],
             borderRadius: theme.radii[1],
             color: theme.colors.white,


### PR DESCRIPTION
This quick ⚡️ PR fixes a minor problem with input padding and sneaks in a couple of visual tweaks

***

### Input
- Removed the right padding so that small inputs don't cut off longer text
- Dialled a nicer text selection height in Safari

Before
<img width="330" alt="Screenshot 2020-01-07 at 19 46 33" src="https://user-images.githubusercontent.com/8441036/71917540-f8efcd80-3188-11ea-84d6-f35bf8a45ba7.png">

After
<img width="330" alt="Screenshot 2020-01-07 at 19 47 37" src="https://user-images.githubusercontent.com/8441036/71917419-b4fcc880-3188-11ea-9344-142a51fa9d8a.png">

***

### Tooltip

Padding update.

Before
<img width="330" alt="Screenshot 2020-01-07 at 19 54 06" src="https://user-images.githubusercontent.com/8441036/71917436-be863080-3188-11ea-804d-d7703c159e4f.png">
After
<img width="330" alt="Screenshot 2020-01-07 at 19 53 44" src="https://user-images.githubusercontent.com/8441036/71917437-bf1ec700-3188-11ea-9ef0-fa35f265782f.png">

***

### Dialog

Dark overlay instead of white overlay

Before
<img width="972" alt="Screenshot 2020-01-07 at 19 54 58" src="https://user-images.githubusercontent.com/8441036/71917458-cf36a680-3188-11ea-89dd-ed182d46d145.png">

After

<img width="972" alt="Screenshot 2020-01-07 at 19 54 49" src="https://user-images.githubusercontent.com/8441036/71917473-d362c400-3188-11ea-8445-90d1f5d0d71b.png">
