### PR TITLE
Add Cursor variant to Input and Textarea

### DIFF
--- a/packages/radix/src/components/Input.story.tsx
+++ b/packages/radix/src/components/Input.story.tsx
@@ -63,5 +63,12 @@ storiesOf('Components|Input', module).add('default', () => (
     <Box mb="4">
       <Input readOnly placeholder="Read only" />
     </Box>
+
+    <Box mb="4">
+      <Input cursor="default" placeholder="Your email" />
+    </Box>
+    <Box mb="4">
+      <Input cursor="text" placeholder="Your email" />
+    </Box>
   </Box>
 ));

--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -3,10 +3,12 @@ import { Input as InputPrimitive, InputProps as InputPrimitiveProps } from 'mdlz
 import { theme } from '../theme';
 
 type Variant = 'normal' | 'ghost';
+type Cursor = 'default' | 'text';
 type Size = 0 | 1;
 
 export type InputProps = InputPrimitiveProps & {
   variant?: Variant;
+  cursor?: Cursor;
   size?: Size & any;
 };
 
@@ -18,7 +20,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
       base: {
         input: {
           normal: {
-            cursor: 'default',
             color: theme.colors.gray800,
             fontFamily: theme.fonts.normal,
             borderRadius: theme.radii[1],
@@ -51,13 +52,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
               },
             },
           },
-          ghost: {
-            input: {
-              normal: {
-                cursor: 'text',
-              },
-            },
-          },
         },
         size: {
           0: {
@@ -85,6 +79,22 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
             },
           },
         },
+        cursor: {
+          text: {
+            input: {
+              normal: {
+                cursor: 'text',
+              },
+            },
+          },
+          default: {
+            input: {
+              normal: {
+                cursor: 'default',
+              },
+            },
+          },
+        },
       },
     }}
   />
@@ -93,5 +103,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
 Input.defaultProps = {
   type: 'text',
   variant: 'normal',
+  cursor: 'text',
   size: 0,
 };

--- a/packages/radix/src/components/Textarea.tsx
+++ b/packages/radix/src/components/Textarea.tsx
@@ -3,10 +3,12 @@ import { Textarea as TextareaPrimitive, TextareaProps as TextareaPrimitiveProps 
 import { theme } from '../theme';
 
 type Variant = 'normal' | 'ghost';
+type Cursor = 'default' | 'text';
 type Size = 0 | 1;
 
 export type TextareaProps = TextareaPrimitiveProps & {
   variant?: Variant;
+  cursor?: Cursor;
   size?: Size & any;
 };
 
@@ -19,7 +21,6 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         base: {
           textarea: {
             normal: {
-              cursor: 'default',
               color: theme.colors.gray800,
               fontFamily: theme.fonts.normal,
               borderRadius: theme.radii[1],
@@ -53,13 +54,6 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
                 },
               },
             },
-            ghost: {
-              textarea: {
-                normal: {
-                  cursor: 'text',
-                },
-              },
-            },
           },
           size: {
             0: {
@@ -86,6 +80,22 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
               },
             },
           },
+          cursor: {
+            text: {
+              textarea: {
+                normal: {
+                  cursor: 'text',
+                },
+              },
+            },
+            default: {
+              textarea: {
+                normal: {
+                  cursor: 'default',
+                },
+              },
+            },
+          },
         },
       }}
     />
@@ -94,5 +104,6 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
 Textarea.defaultProps = {
   variant: 'normal',
+  cursor: 'text',
   size: 0,
 };

--- a/packages/website/src/docs/input.mdx
+++ b/packages/website/src/docs/input.mdx
@@ -20,9 +20,13 @@ description: Useful for allowing users to enter, update and select text.
       default: 'normal',
       description: 'The variant to apply',
     },
+    cursor: {
+      type: 'text | default',
+      default: 'text',
+      description: 'The cursor to apply',
+    },
   }}
 />
-
 <SystemProps
   props={['textColor', 'margin', 'padding', 'width', 'maxWidth', 'textAlign']}
 />
@@ -45,4 +49,13 @@ There are 2 variants to choose from.
 ```js live
 <Input value="your@email.io" variant="normal" />
 <Input value="your@email.io" mt={6} variant="ghost" />
+```
+
+### Cursors
+
+There are 2 cursors to choose from.
+
+```js live
+<Input value="your@email.io" cursor="text" />
+<Input value="your@email.io" mt={6} cursor="default" />
 ```

--- a/packages/website/src/docs/textarea.mdx
+++ b/packages/website/src/docs/textarea.mdx
@@ -20,9 +20,42 @@ description: Useful for allowing users to enter, update and select text.
       default: 'normal',
       description: 'The variant to apply',
     },
+    cursor: {
+      type: 'text | default',
+      default: 'text',
+      description: 'The cursor to apply',
+    },
   }}
 />
-
 <SystemProps
   props={['textColor', 'margin', 'padding', 'width', 'maxWidth', 'textAlign']}
 />
+
+## Examples
+
+### Size
+
+There are 2 sizes to choose from.
+
+```js live
+<Textarea placeholder="Your comment here" />
+<Textarea placeholder="Your comment here" mt={6} size={1} />
+```
+
+### Variants
+
+There are 2 variants to choose from.
+
+```js live
+<Textarea value="This is your comment" variant="normal" />
+<Textarea value="This is your comment" mt={6} variant="ghost" />
+```
+
+### Cursors
+
+There are 2 cursors to choose from.
+
+```js live
+<Textarea value="This is your comment" cursor="text" />
+<Textarea value="This is your comment" mt={6} cursor="default" />
+```


### PR DESCRIPTION
Closes #188

Given time and effort, I find this to be the most appropriate solution to #188 

- By default, `Input` and `Textarea` will use `cursor: text`
- If the variant `cursor="default"` is provided, it will use `cursor: default`

This will give us enough control and flexibility in Modulz to decide which type of Cursor we want to use without having to wrap it in another SC.