### PR TITLE
Input padding and text alignment

### DIFF
--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -61,8 +61,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 letterSpacing: '-0.01em',
                 height: theme.sizes[5],
                 lineHeight: theme.lineHeights[0], // Yields nice text selection height in Safari
-                paddingLeft: theme.space[1],
-                paddingRight: 1, // Makes up for the inset box shadow so it doesn't overlap
+
+                // Set padding against text alignment so that long values don't cut off at the other side
+                // "1" makes up for the inset box shadow so that text doesn't overlap with it
+                paddingLeft: props.textAlign === 'left' || !props.textAlign ? theme.space[1] : 1,
+                paddingRight: props.textAlign === 'right' ? theme.space[1] : 1,
               },
             },
           },
@@ -73,8 +76,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 letterSpacing: '-0.01em',
                 height: theme.sizes[6],
                 lineHeight: theme.lineHeights[0], // Yields nice text selection height in Safari
-                paddingLeft: theme.space[2],
-                paddingRight: 1, // Makes up for the inset box shadow so it doesn't overlap
+
+                // Set padding against text alignment so that long values don't cut off at the other side
+                // "1" makes up for the inset box shadow so that text doesn't overlap with it
+                paddingLeft: props.textAlign === 'left' || !props.textAlign ? theme.space[2] : 1,
+                paddingRight: props.textAlign === 'right' ? theme.space[2] : 1,
               },
             },
           },

--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -61,11 +61,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 letterSpacing: '-0.01em',
                 height: theme.sizes[5],
                 lineHeight: theme.lineHeights[0], // Yields nice text selection height in Safari
-
-                // Set padding against text alignment so that long values don't cut off at the other side
-                // "1" makes up for the inset box shadow so that text doesn't overlap with it
-                paddingLeft: props.textAlign === 'left' || !props.textAlign ? theme.space[1] : 1,
-                paddingRight: props.textAlign === 'right' ? theme.space[1] : 1,
+                paddingLeft: theme.space[1],
+                paddingRight: theme.space[1],
               },
             },
           },
@@ -76,11 +73,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 letterSpacing: '-0.01em',
                 height: theme.sizes[6],
                 lineHeight: theme.lineHeights[0], // Yields nice text selection height in Safari
-
-                // Set padding against text alignment so that long values don't cut off at the other side
-                // "1" makes up for the inset box shadow so that text doesn't overlap with it
-                paddingLeft: props.textAlign === 'left' || !props.textAlign ? theme.space[2] : 1,
-                paddingRight: props.textAlign === 'right' ? theme.space[2] : 1,
+                paddingLeft: theme.space[2],
+                paddingRight: theme.space[2],
               },
             },
           },


### PR DESCRIPTION
**Edit**: reverted to simpler symmetrical paddings.

Previous comment for history:

***

Heads up, this might be a _biiiit_ controversial, although solves a real problem. Up for discussion.

We previously ditched the right padding on inputs so that longer text isn't cut off at the side, which was apparent in the editor. However, this messes with inputs that have text aligned to center and right.

***

**Before**
<img src="https://user-images.githubusercontent.com/8441036/73093674-b3046a80-3ee7-11ea-9229-196558fcb704.png" width="330" />

***

**After**
<img src="https://user-images.githubusercontent.com/8441036/73093721-c7e0fe00-3ee7-11ea-8ac6-a1983c703abc.png" width="330" />

***

Technically, this is the same as what we have for the [conditional letter spacing that depends on weight](https://github.com/modulz/radix/blob/bedb32ac7731afb5f61912d9fe2763b832707f28/packages/radix/src/components/Text.tsx#L36). Like conditional letter spacing, we won't be able to reproduce this in Modulz app when Radix is generated by Modulz; unless we factor it in.

Alternatively, we can revert to symmetrical paddings and, when needed, overwrite a padding manually when using Inputs in a tight setting, if that's OK.