### PR TITLE
Revise focus styles

### DIFF
--- a/packages/radix/src/components/Button.tsx
+++ b/packages/radix/src/components/Button.tsx
@@ -63,7 +63,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
                   boxShadow: `inset 0 0 0 1px ${theme.colors.gray500}`,
                 },
                 focus: {
-                  boxShadow: `inset 0 0 0 1px ${theme.colors.blue500}, 0 0 0 1px ${theme.colors.blue500}`,
+                  boxShadow: `inset 0 0 0 1px ${theme.colors.gray500}, 0 0 0 1px ${theme.colors.gray500}`,
                 },
               },
             },

--- a/packages/radix/src/components/CardLink.tsx
+++ b/packages/radix/src/components/CardLink.tsx
@@ -20,7 +20,8 @@ const cardLinkStyleConfigOverrides: StyleConfig<CardLinkParts> = {
     card: {
       normal: {},
       focus: {
-        borderColor: theme.colors.blue600,
+        borderColor: theme.colors.blue500,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.blue500}`,
       },
     },
   },

--- a/packages/radix/src/components/Checkbox.tsx
+++ b/packages/radix/src/components/Checkbox.tsx
@@ -18,18 +18,18 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
             width: theme.sizes[4],
             height: theme.sizes[4],
             borderRadius: theme.radii[1],
-            border: '1px solid',
-            borderColor: theme.colors.gray400,
+            border: 0,
+            boxShadow: `inset 0 0 0 1px ${theme.colors.gray400}`,
           },
           hover: {
-            borderColor: theme.colors.gray500,
+            boxShadow: `inset 0 0 0 1px ${theme.colors.gray500}`,
           },
           focus: {
-            borderColor: theme.colors.gray600,
+            boxShadow: `inset 0 0 0 1px ${theme.colors.blue500}, 0 0 0 1px ${theme.colors.blue500}`,
           },
           checked: {
             backgroundColor: theme.colors.blue600,
-            borderColor: theme.colors.blue600,
+            boxShadow: 'none',
           },
           disabled: {
             opacity: 0.5,

--- a/packages/radix/src/components/GhostButton.tsx
+++ b/packages/radix/src/components/GhostButton.tsx
@@ -48,7 +48,7 @@ export const GhostButton = React.forwardRef<HTMLButtonElement, GhostButtonProps>
               cursor: 'not-allowed',
             },
             focus: {
-              boxShadow: `0 0 0 2px ${theme.colors.blue500}`,
+              boxShadow: `0 0 0 2px ${theme.colors.gray500}`,
             },
           },
         },

--- a/packages/radix/src/components/Link.tsx
+++ b/packages/radix/src/components/Link.tsx
@@ -14,6 +14,9 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, forwa
           normal: {
             color: theme.colors.blue700,
           },
+          focus: {
+            boxShadow: `0 0 0 2px ${theme.colors.blue500}`,
+          },
         },
       },
     }}

--- a/packages/radix/src/components/List.tsx
+++ b/packages/radix/src/components/List.tsx
@@ -96,7 +96,7 @@ export const ListItem = styled('button')<ListItemProps>(
             backgroundColor: 'gray300',
           },
           '&:focus': {
-            outlineColor: themeGet('colors.blue400')(props),
+            outlineColor: themeGet('colors.gray400')(props),
           },
         },
         active: {
@@ -107,6 +107,9 @@ export const ListItem = styled('button')<ListItemProps>(
           },
           '&:active': {
             backgroundColor: 'blue600',
+          },
+          '&:focus': {
+            outlineColor: themeGet('colors.blue500')(props),
           },
         },
         selected: {

--- a/packages/radix/src/components/Radio.tsx
+++ b/packages/radix/src/components/Radio.tsx
@@ -22,7 +22,8 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>((props, forw
             borderColor: theme.colors.gray500,
           },
           focus: {
-            borderColor: theme.colors.blue600,
+            borderColor: theme.colors.blue500,
+            boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
           },
           disabled: {
             opacity: 0.5,

--- a/packages/radix/src/components/Select.tsx
+++ b/packages/radix/src/components/Select.tsx
@@ -37,7 +37,7 @@ const selectStyleConfigOverrides: StyleConfig<SelectParts> = {
         flexWrap: 'wrap', // allows the button to shrink
       },
       focus: {
-        boxShadow: `inset 0 0 0 1px ${theme.colors.blue500}, 0 0 0 1px ${theme.colors.blue500}`,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.gray500}, 0 0 0 1px ${theme.colors.gray500}`,
       },
       disabled: {
         color: theme.colors.gray500,

--- a/packages/radix/src/components/ToggleButton.tsx
+++ b/packages/radix/src/components/ToggleButton.tsx
@@ -81,8 +81,8 @@ export const ToggleButtonGroup = <T extends string | string[] | null>(
                 borderColor: theme.colors.gray500,
               },
               focus: {
-                borderColor: theme.colors.blue500,
-                boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
+                borderColor: theme.colors.gray500,
+                boxShadow: `0 0 0 1px ${theme.colors.gray500}`,
               },
               toggled: {
                 color: theme.colors.blue800,
@@ -92,7 +92,7 @@ export const ToggleButtonGroup = <T extends string | string[] | null>(
                 borderColor: 'transparent',
                 backgroundColor: theme.colors.blue100,
                 boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
-                '&:focus': {
+                '&:not(:disabled):focus': {
                   borderColor: theme.colors.blue500,
                   boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
                 },
@@ -111,15 +111,15 @@ export const ToggleButtonGroup = <T extends string | string[] | null>(
               },
               focus: {
                 color: theme.colors.gray700,
-                borderColor: theme.colors.blue500,
-                boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
+                borderColor: theme.colors.gray500,
+                boxShadow: `0 0 0 1px ${theme.colors.gray500}`,
               },
               toggled: {
                 color: theme.colors.gray700,
                 borderColor: 'transparent',
                 backgroundColor: theme.colors.gray100,
                 boxShadow: `0 0 0 1px ${theme.colors.gray400}`,
-                '&:focus': {
+                '&:not(:disabled):focus': {
                   borderColor: theme.colors.blue500,
                   boxShadow: `0 0 0 1px ${theme.colors.blue500}`,
                 },

--- a/packages/website/src/now.json
+++ b/packages/website/src/now.json
@@ -1,0 +1,3 @@
+{
+  "redirects": [{ "source": "/", "destination": "/docs/getting-started" }]
+}

--- a/packages/website/src/now.json
+++ b/packages/website/src/now.json
@@ -1,3 +1,0 @@
-{
-  "redirects": [{ "source": "/", "destination": "/docs/getting-started" }]
-}


### PR DESCRIPTION
This PR is a pragmatic design workaround to _not_ do https://github.com/modulz/modulz/issues/657

***

Changed from blue focus ring to gray focus ring:
- Button, gray variant
- Select
- Ghost Button, inactive variant
- Toggle Button, inactive variant
- List Item, inactive variant

Added focus styles that were missing:
- Link

Changed from a thin blue focus ring to a thick one:
- Card Link
- Checkbox
- Radio

Demos:
https://radix-cpdhtbbs9.now.sh/docs/popover/
https://radix-cpdhtbbs9.now.sh/docs/ghost-button/

***

Thought process:
- I figured that doing `focus-visible` is going to open a can of worms that we don't want to deal with, no matter whether we are looking at this feature conservatively or not. So I decided to see if this issue may simply be mitigated by adjusting focus styles slightly.
- Initially, I had an idea to add a slight 100-200ms transition for box shadow on `:focus`. I did it and it was terrible. The focus ring just lagged behind mouse clicks, which drew even more attention. Not even sharing those demos 😀
- Since the main offender with mouse interactions was the stark contrast of gray & blue, replacing blue focus ring with gray on gray components solved the issue for me.
  - The update introduces a slight design inconsistency which I personally find helpful — this gets us stronger focus styles for the most CTA-ish elements (e.g. blue buttons) and calmer focus styles for currently inactive and less important elements. Should be fine if we think about focus as an extension of the normal styles.
  - In Modulz, I think this update will greatly reduce how harsh the focused Ghost Buttons look when popovers open and close, yet staying prominent on the screen.

***

Fun fact:
- Green and red buttons have been using green and red focus outlines respectively, but both gray and blue buttons had been using a blue outline. Now this is even and consistent 👌 

***

<img src="https://user-images.githubusercontent.com/8441036/74545410-81fce000-4f51-11ea-80c2-0e1aa4442ebf.png" width="828" />
