### PR TITLE
Remove unnecessary docs props

### DIFF
--- a/packages/website/src/docs/grid.mdx
+++ b/packages/website/src/docs/grid.mdx
@@ -6,16 +6,16 @@ description: A primitive useful for grid layouts.
 
 ```js live
 <Grid gridTemplateColumns="repeat(5, 1fr)" gridGap={6}>
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
-  <AspectRatio width={5} height={5} bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
+  <AspectRatio bg="blue600" />
 </Grid>
 ```
 


### PR DESCRIPTION
The `width` and `height` props doesn't affect the grid items and are ending up as attributes in the DOM. The live example works the same without them.