### PR TITLE
fix yarn start

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository is a [monorepo](https://github.com/babel/babel/blob/master/doc/d
 yarn
 ```
 
-#### Build Radix library
+#### Initialise after the first install
 
 ```sh
 yarn init

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This repository is a [monorepo](https://github.com/babel/babel/blob/master/doc/d
 yarn
 ```
 
+#### Build Radix library
+
+```sh
+yarn init
+```
+
 #### Run website + Radix
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "init": "yarn radix-system:build && yarn radix:build",
-    "start": "npm-run-all --parallel radix-system radix radix:storybook website",
+    "start": "npm-run-all init --parallel radix-system radix radix:storybook website",
     "website": "lerna exec --scope website -- yarn start",
     "website:build": "lerna exec --scope website -- yarn build",
     "radix": "lerna exec --scope @modulz/radix -- yarn watch",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "init": "yarn radix-system:build && yarn radix:build",
-    "start": "npm-run-all init --parallel radix-system radix radix:storybook website",
+    "start": "npm-run-all --parallel radix-system radix radix:storybook website",
     "website": "lerna exec --scope website -- yarn start",
     "website:build": "lerna exec --scope website -- yarn build",
     "radix": "lerna exec --scope @modulz/radix -- yarn watch",


### PR DESCRIPTION
fix the issue after cloning the repo and run command `yarn start` cause error when starting docs site. because of radix still not build.