### PR TITLE
Fix breakpoint scaling in Safari and set container width

### DIFF
--- a/packages/radix/src/components/Container.tsx
+++ b/packages/radix/src/components/Container.tsx
@@ -31,21 +31,21 @@ export const Container = React.forwardRef<HTMLDivElement, ContainerProps>((props
           0: {
             container: {
               normal: {
-                maxWidth: '25rem',
+                maxWidth: 375,
               },
             },
           },
           1: {
             container: {
               normal: {
-                maxWidth: '45rem',
+                maxWidth: 685,
               },
             },
           },
           2: {
             container: {
               normal: {
-                maxWidth: '65rem',
+                maxWidth: 985,
               },
             },
           },

--- a/packages/radix/src/theme.ts
+++ b/packages/radix/src/theme.ts
@@ -1,12 +1,12 @@
 type RadixBreakpoints<T> = Array<T> & {
   small: 0;
-  medium: '38em';
-  large: '62em';
-  xlarge: '68em';
+  medium: '600px';
+  large: '1000px';
+  xlarge: '1080px';
 };
 
 export const theme = {
-  breakpoints: ['38em', '62em', '68em', '110em'] as RadixBreakpoints<any>,
+  breakpoints: ['600px', '1000px', '1080px', '1760px'] as RadixBreakpoints<any>,
   fonts: {
     normal:
       'UntitledSans, -apple-system, BlinkMacSystemFont, "Helvetica Neue", helvetica, arial, sans-serif',


### PR DESCRIPTION
- Set breakpoints to `px` as well since `em` breakpoints are broken in Safari. [Adam Wathan](https://adamwathan.me/dont-use-em-for-media-queries/) wrote an extensive article about it.
- Set Container units to px for consistent scaling behaviour with other components
- Slightly changed Container width to harmonise derived grid layouts to the space scale better
  - Getting this in while it has almost no effects on current Container usage, so there's foundation for easier design work down the road.

***

The slightly updated container widths are based on a traditional 12-column grid:
- `25rem` computed at `375px` stays
    - Only units changed
- `45rem` computed at `675px` → `685px`
    - This is 12 columns at `30px` with gutters at `25px`
- `65rem` computed at `975px` → `985px`
    - This is 12 columns at `55px` with gutters at `25px`

New sizes yield multi-column layouts that lend themselves to faster work in drawing tools because grids of 2, 3, 4, 6 columns have integer column widths now. A bit later we can look into adding variants to the Grid component to encourage layout consistency.