### PR TITLE
Add SX Prop in Radix System

### DIFF
--- a/packages/radix-system/package.json
+++ b/packages/radix-system/package.json
@@ -21,8 +21,9 @@
   },
   "dependencies": {
     "@styled-system/core": "^5.1.2",
-    "@styled-system/css": "^5.1.4",
+    "@styled-system/css": "^5.1.5",
     "@types/styled-system__core": "npm:@peduarte/styled-system__core",
+    "@types/styled-system__css": "^5.0.5",
     "csstype": "^2.6.7"
   },
   "devDependencies": {

--- a/packages/radix-system/src/index.ts
+++ b/packages/radix-system/src/index.ts
@@ -15,8 +15,6 @@ export { minWidth, MinWidthProps } from './system/minWidth';
 export { width, WidthProps } from './system/width';
 export { overflow, OverflowProps } from './system/overflow';
 
-export { margin, MarginProps } from './system/margin';
-export { padding, PaddingProps } from './system/padding';
 export { border, BorderProps } from './system/border';
 export { borderRadius, BorderRadiusProps } from './system/borderRadius';
 
@@ -24,6 +22,11 @@ export { boxShadow, BoxShadowProps } from './system/boxShadow';
 export { opacity, OpacityProps } from './system/opacity';
 export { backgroundColor, BackgroundColorProps } from './system/backgroundColor';
 export { textColor, TextColorProps } from './system/textColor';
+
+// Space set
+export { spaceSet, SpaceSetProps } from './system/space';
+export { margin, MarginProps } from './system/space/margin';
+export { padding, PaddingProps } from './system/space/padding';
 
 // Flex Container Set
 export { flexContainerSet, FlexContainerSetProps } from './system/flexContainer';
@@ -69,6 +72,8 @@ export { gridTemplateAreas, GridTemplateAreasProps } from './system/grid/gridTem
 export { gridArea, GridAreaProps } from './system/grid/gridArea';
 
 export { variant } from './utils/variant';
+
+export { sx, SxProp } from './utils/sx';
 
 export { system, createParser, compose, get } from '@styled-system/core';
 

--- a/packages/radix-system/src/system/space/index.ts
+++ b/packages/radix-system/src/system/space/index.ts
@@ -1,0 +1,10 @@
+import { system } from '@styled-system/core';
+import { config as marginConfig, MarginProps } from './margin';
+import { config as paddingConfig, PaddingProps } from './padding';
+
+export interface SpaceSetProps extends MarginProps, PaddingProps {}
+
+export const spaceSet = system({
+  ...marginConfig,
+  ...paddingConfig,
+});

--- a/packages/radix-system/src/system/space/margin.test.tsx
+++ b/packages/radix-system/src/system/space/margin.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { margin, MarginProps } from './margin';
-import { styled } from '../utils/test';
+import { styled } from '../../utils/test';
 
 const Component: React.ComponentType<MarginProps> = styled`
   ${margin};

--- a/packages/radix-system/src/system/space/margin.ts
+++ b/packages/radix-system/src/system/space/margin.ts
@@ -1,7 +1,7 @@
 import * as CSS from 'csstype';
 import { system, Config } from '@styled-system/core';
-import { getNegativeSpace } from '../utils/getNegativeSpace';
-import { Prop, Length } from '../utils/types';
+import { getNegativeSpace } from '../../utils/getNegativeSpace';
+import { Prop, Length } from '../../utils/types';
 
 export interface MarginProps {
   m?: Prop<CSS.MarginProperty<Length>>;
@@ -20,7 +20,7 @@ export interface MarginProps {
   marginY?: Prop<CSS.MarginProperty<Length>>;
 }
 
-const config: Config = {
+export const config: Config = {
   margin: {
     property: 'margin',
     scale: 'space',

--- a/packages/radix-system/src/system/space/padding.test.tsx
+++ b/packages/radix-system/src/system/space/padding.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { padding, PaddingProps } from './padding';
-import { styled } from '../utils/test';
+import { styled } from '../../utils/test';
 
 const Component: React.ComponentType<PaddingProps> = styled`
   ${padding};

--- a/packages/radix-system/src/system/space/padding.ts
+++ b/packages/radix-system/src/system/space/padding.ts
@@ -1,6 +1,6 @@
 import * as CSS from 'csstype';
 import { system, Config } from '@styled-system/core';
-import { Prop, Length } from '../utils/types';
+import { Prop, Length } from '../../utils/types';
 
 export interface PaddingProps {
   p?: Prop<CSS.PaddingProperty<Length>>;
@@ -19,7 +19,7 @@ export interface PaddingProps {
   paddingY?: Prop<CSS.PaddingProperty<Length>>;
 }
 
-const config: Config = {
+export const config: Config = {
   padding: {
     property: 'padding',
     scale: 'space',

--- a/packages/radix-system/src/types/index.d.ts
+++ b/packages/radix-system/src/types/index.d.ts
@@ -1,1 +1,0 @@
-declare module '@styled-system/css';

--- a/packages/radix-system/src/utils/sx.test.tsx
+++ b/packages/radix-system/src/utils/sx.test.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { styled } from './test';
+import { sx, SxProp } from './sx';
+
+const Component: React.ComponentType<SxProp> = styled`
+  ${sx};
+`;
+
+export const test = () => (
+  <>
+    <Component sx={{ bg: 'red' }} />
+    <Component sx={{ bg: ['red', 'blue'] }} />
+  </>
+);

--- a/packages/radix-system/src/utils/sx.ts
+++ b/packages/radix-system/src/utils/sx.ts
@@ -1,0 +1,5 @@
+import css, { SystemStyleObject } from '@styled-system/css';
+
+export type SxProp = { sx?: SystemStyleObject; theme?: Object };
+
+export const sx = ({ sx, theme }: SxProp) => css(sx)(theme);

--- a/packages/radix-system/src/utils/variant.ts
+++ b/packages/radix-system/src/utils/variant.ts
@@ -10,5 +10,5 @@ export const variant = (config: any) => (props: any) => {
     createParser({
       [prop]: getValue,
     })(props)
-  );
+  ) as any;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,10 +2548,15 @@
   dependencies:
     object-assign "^4.1.1"
 
-"@styled-system/css@5.1.4", "@styled-system/css@^5.1.4":
+"@styled-system/css@5.1.4":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-5.1.4.tgz#fc51d0789a69b3831e00e6f8daf9f1d345eebdc3"
   integrity sha512-79IFT37Kxb6dlbx/0hwIGOakNHkK5oU3cMypGziShnEK8WMgK/+vuAi4MHO7uLI+FZ5U8MGYvGY9Gtk0mBzxSg==
+
+"@styled-system/css@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@styled-system/css/-/css-5.1.5.tgz#0460d5f3ff962fa649ea128ef58d9584f403bbbc"
+  integrity sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==
 
 "@styled-system/theme-get@^5.1.2":
   version "5.1.2"
@@ -2845,6 +2850,13 @@
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@peduarte/styled-system__core/-/styled-system__core-0.0.1.tgz#de78b6aa193c39d9029d3ed036bd481ad6a5b925"
   integrity sha512-s3CtmKoSZCyOZfe03ftUrOqVhFTryWuQhs0koYOvyoNnsMtV+NDvMSFf/SHxl9uvy/jp20qkkFlIVu0x9WJOFA==
+
+"@types/styled-system__css@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@types/styled-system__css/-/styled-system__css-5.0.5.tgz#f3c8036e551fbf603f1ad39cf317fd0e6ad1e431"
+  integrity sha512-JaKYusiRtP3osDx+PhTPP7Ki68mMKoImv/bhr7lK4UFAxeXvveARD5v5rUY0Oy0pfbNkky/nVgHlgGaPbG/JBQ==
+  dependencies:
+    csstype "^2.6.6"
 
 "@types/tmp@^0.0.32":
   version "0.0.32"
@@ -5816,6 +5828,11 @@ csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
   integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
+
+csstype@^2.6.6:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
+  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This PR Adds SX Prop to Radix System so we can implement it in Primitives.

The usage would be something like this:

```tsx
import styled from 'styled-components';
import {
  sx,
  SxProp,
  spaceSet,
  SpaceSetProps,
} from '@modulz/radix-system';


type BoxDOMProps = React.ComponentPropsWithRef<'div'>;
type BoxSystemProps = SxProp & SpaceSetProps & TextColorProps;
type BoxProps = BoxDOMProps & BoxSystemProps;

const Box = styled('div')<BoxProps>(
  spaceSet,
  sx
);
```

It also introduced a new `SpaceSet` which groups `padding` and `margin` system props

