### PR TITLE
fix(Table): padding right offset

### DIFF
--- a/packages/radix/src/components/Table.tsx
+++ b/packages/radix/src/components/Table.tsx
@@ -35,6 +35,9 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>((props, forw
             fontSize: theme.fontSizes[1],
             fontVariantNumeric: 'tabular-nums',
             lineHeight: theme.lineHeights[2],
+            '&:last-of-type': {
+              paddingRight: 0,
+            },
           },
         },
         td: {
@@ -47,6 +50,9 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>((props, forw
             fontSize: theme.fontSizes[2],
             fontVariantNumeric: 'tabular-nums',
             lineHeight: theme.lineHeights[2],
+            '&:last-of-type': {
+              paddingRight: 0,
+            },
           },
         },
       },

--- a/packages/website/src/docs/Table.mdx
+++ b/packages/website/src/docs/Table.mdx
@@ -9,7 +9,7 @@ description: Useful to display tabular data in row format.
   <Thead>
     <Tr>
       <Th>Name</Th>
-      <Th>Instument</Th>
+      <Th>Instrument</Th>
       <Th>Date of birth</Th>
     </Tr>
   </Thead>


### PR DESCRIPTION
Currently, `th` and `td` are offset in Table due to padding on the right. It's not a big deal but stood out to me since it can cause unnecessary wrapping of text.

## Current

![image](https://user-images.githubusercontent.com/23662329/77321615-19a4d980-6d1b-11ea-8761-485e378a31d4.png)

## Change

![image](https://user-images.githubusercontent.com/23662329/77321665-2cb7a980-6d1b-11ea-955a-298df5425508.png)
