### PR TITLE
Handle disable lock in Menu story

### DIFF
--- a/packages/radix/package.json
+++ b/packages/radix/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "@modulz/primitives": "0.0.1-19",
+    "@modulz/primitives": "0.0.1-20",
     "@modulz/radix-system": "0.0.1-alpha.11",
     "@styled-system/css": "5.1.4",
     "@styled-system/theme-get": "^5.1.2",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.5.5",
     "@mdx-js/react": "^1.5.5",
-    "@modulz/radix": "^0.0.1-beta.28",
+    "@modulz/primitives": "0.0.1-20",
+    "@modulz/radix": "0.0.1-beta.28",
     "@modulz/radix-icons": "2.0.0",
     "@modulz/radix-system": "0.0.1-alpha.11",
     "babel-plugin-styled-components": "^1.10.7",

--- a/packages/website/src/docs/menu.mdx
+++ b/packages/website/src/docs/menu.mdx
@@ -2,6 +2,7 @@
 title: Menu
 component: Menu
 description: Useful for displaying a list of actions. Typically not used directly but in conjunction with other components like RightClickMenu or DropdownMenu.
+disableLock: true
 ---
 
 ```js live removeFragment
@@ -13,7 +14,7 @@ description: Useful for displaying a list of actions. Typically not used directl
   return (
     <Box sx={{ height: '243px' }}>
       <div ref={targetRef} />
-      <Menu isOpen buttonRef={targetRef} unstable__disableLock>
+      <Menu isOpen buttonRef={targetRef}>
         <MenuItem label="Simple item one" />
         <MenuItem label="Simple item two" />
         <MenuItem label="Simple item three" />

--- a/packages/website/src/templates/doc-page.js
+++ b/packages/website/src/templates/doc-page.js
@@ -5,6 +5,7 @@ import { MDXProvider } from '@mdx-js/react';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import * as RC from '@modulz/radix';
 import * as RI from '@modulz/radix-icons';
+import { DebugContextProvider } from '@modulz/primitives';
 import Layout from '../components/Layout';
 import CodeBlock from '../components/CodeBlock';
 import { PropsTable } from '../components/PropsTable';
@@ -75,7 +76,11 @@ function DocPageTemplate({ data, location, ...props }) {
           >
             {data.mdx.frontmatter.description}
           </RC.Heading>
-          {children}
+          {data.mdx.frontmatter.disableLock === true ? (
+            <DebugContextProvider disableLock>{children}</DebugContextProvider>
+          ) : (
+            children
+          )}
         </RC.Box>
       </MDXProvider>
     </Layout>
@@ -92,6 +97,7 @@ export const pageQuery = graphql`
         title
         component
         description
+        disableLock
       }
       body
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,10 +1937,10 @@
   resolved "https://registry.yarnpkg.com/@mikaelkristiansson/domready/-/domready-1.0.10.tgz#f6d69866c0857664e70690d7a0bfedb72143adb5"
   integrity sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg==
 
-"@modulz/primitives@0.0.1-19":
-  version "0.0.1-19"
-  resolved "https://registry.yarnpkg.com/@modulz/primitives/-/primitives-0.0.1-19.tgz#2f73e0b0ab256cf84f241f608af8c3a3fb350a31"
-  integrity sha512-tS9GIVIlrf6PuBWpHytZO1SAeYZZn1pMb1AqKjFRB107YzcFa7GjVklGZFCC1JPN8kp4glje0zHlseoD4KLk3g==
+"@modulz/primitives@0.0.1-20":
+  version "0.0.1-20"
+  resolved "https://registry.yarnpkg.com/@modulz/primitives/-/primitives-0.0.1-20.tgz#ed70872b02d045777059ee537cd2592e8ceea1d2"
+  integrity sha512-YGyUVdF/ammw8ZAw3zSpbg80mkhQXni0zqv0tFtThUbJtIU8QRLelvT8CQHGCIVDbxDjec4wv7rTGmU6IUl3fw==
   dependencies:
     "@modulz/radix-icons" "2.0.0"
     "@modulz/radix-system" "0.0.1-alpha.11"


### PR DESCRIPTION
This PR handles disabling the lock in a different way now that we have the DebugContextProvider.
I'm currently using the frontmatter for this, which is suitable, and it's all completely different in the real styleguide anyway.