### PR TITLE
Add hover style to the ghost Select variant

### DIFF
--- a/packages/radix/src/components/Select.tsx
+++ b/packages/radix/src/components/Select.tsx
@@ -70,7 +70,16 @@ const selectStyleConfigOverrides: StyleConfig<SelectParts> = {
           },
         },
       },
-      ghost: {},
+      ghost: {
+        button: {
+          normal: {
+            mixBlendMode: 'multiply',
+          },
+          hover: {
+            backgroundColor: theme.colors.gray200,
+          },
+        },
+      },
     },
     size: {
       0: {


### PR DESCRIPTION
Adding a hover style to the ghost Select variant that matches the Ghost Button hover style

<img src="https://user-images.githubusercontent.com/8441036/77515723-bc776800-6e81-11ea-8ab0-081eff657dc8.gif" width="210" />