### PR TITLE
Add a11y Storybook addon

### DIFF
--- a/packages/radix/.storybook/addons.js
+++ b/packages/radix/.storybook/addons.js
@@ -1,0 +1,1 @@
+import '@storybook/addon-a11y/register';

--- a/packages/radix/.storybook/config.js
+++ b/packages/radix/.storybook/config.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { addDecorator, configure } from '@storybook/react';
+import { withA11y } from '@storybook/addon-a11y';
 import { RadixProvider } from '../src/RadixProvider';
 import { Box } from '../src';
 
@@ -12,6 +13,7 @@ function ThemeComponent({ children }) {
 }
 
 addDecorator((story, context) => <ThemeComponent>{story()}</ThemeComponent>);
+addDecorator(withA11y);
 
 configure(loadStories, module);
 

--- a/packages/radix/package.json
+++ b/packages/radix/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@babel/core": "^7.7.5",
     "@modulz/radix-icons": "2.0.0",
+    "@storybook/addon-a11y": "5.2.8",
     "@storybook/addon-options": "5.2.8",
     "@storybook/addons": "5.2.8",
     "@storybook/react": "5.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,6 +2134,29 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@storybook/addon-a11y@5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-5.2.8.tgz#30ca043dd376711eed9dd4443410d70754050178"
+  integrity sha512-rIujvSAmXhivMecdTAqIwWQ0PARLBmMBKqdLtCfkfwtRjfASJxEFGWRmRJramx37vIDYWS5r7uHfUpZbYSn6Fg==
+  dependencies:
+    "@storybook/addons" "5.2.8"
+    "@storybook/api" "5.2.8"
+    "@storybook/client-logger" "5.2.8"
+    "@storybook/components" "5.2.8"
+    "@storybook/core-events" "5.2.8"
+    "@storybook/theming" "5.2.8"
+    axe-core "^3.3.2"
+    common-tags "^1.8.0"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    hoist-non-react-statics "^3.3.0"
+    memoizerific "^1.11.3"
+    react "^16.8.3"
+    react-redux "^7.0.2"
+    react-sizeme "^2.5.2"
+    redux "^4.0.1"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-options@5.2.8":
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/@storybook/addon-options/-/addon-options-5.2.8.tgz#579c7e1f331303382541fa77c1c26242d7d6b79d"
@@ -3567,6 +3590,11 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+
+axe-core@^3.3.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.3.tgz#5b7c0ee7c5197d546bd3a07c3ef701896f5773e9"
+  integrity sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==
 
 axios@^0.19.0:
   version "0.19.2"
@@ -13434,6 +13462,11 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
+react-is@^16.9.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -13484,6 +13517,17 @@ react-reconciler@^0.24.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
+react-redux@^7.0.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
+
 react-refresh@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.7.2.tgz#f30978d21eb8cac6e2f2fde056a7d04f6844dd50"
@@ -13501,7 +13545,7 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-sizeme@^2.6.7:
+react-sizeme@^2.5.2, react-sizeme@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"
   integrity sha512-tL4sCgfmvapYRZ1FO2VmBmjPVzzqgHA7kI8lSJ6JS6L78jXFNRdOZFpXyK6P1NBZvKPPCZxReNgzZNUajAerZw==
@@ -13763,7 +13807,7 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.5:
+redux@^4.0.1, redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==


### PR DESCRIPTION
Hi! I watched Pedro’s presentation of Modulz this afternoon and it looks amazing, good job! It prompted me to play around with radix and do some quick accessibility checks to test the primitives 🙈 

# This PR

Although I’m guessing you’ll move away from Storybook at some point, I’ve noticed a few accessibility issues in the Radix components. This PR sets up a [storybook addon](https://www.npmjs.com/package/@storybook/addon-a11y) that should help avoid those in the future.

The addon uses [axe](https://github.com/dequelabs/axe-core) under the hood, which is an accessibility testing engine. It can sometimes report false positives but I didn’t notice any while playing around, and you can totally customize axe to ignore some errors, so IMO there is never a strong reason not to install this addon, but that’s obviously up to you! I set it up during my tests so I figured I could just open a PR.

Here’s an example of what it looks like when browsing the Button component:
<img width="1231" alt="Screenshot 2020-04-09 at 18 20 45" src="https://user-images.githubusercontent.com/9154236/78917198-dbcfe100-7a8e-11ea-8299-90cde3bfa7db.png">

It also adds a color blindness control which can be handy:
<img width="918" alt="Screenshot 2020-04-09 at 18 39 06" src="https://user-images.githubusercontent.com/9154236/78918919-6d405280-7a91-11ea-92ae-e88f10a71f94.png">

Will Modulz include something similar, or at least a color contrast check? That’d be a great feature. :)

# Accessibility issues

I know Radix and your primitives are WIP but here’s a non exhaustive list of a11y issues I found, in no particular order (some of them are not reported by the addon).

## In Radix

- The `blue` variant doesn’t pass the WCAG contrast ratio test (in both `Button` and `Badge`). Same for the `normal` variant of `Code`, the `highlight` variant of `Link`, the `fade` variant of the `ToggleButton` and the `active` variant of `List`.
- The waiting button has a focus outline but it’s almost invisible.
- The `Switch` and `Checkbox` components don’t have focus states, but you have some opened issues for those already. There’s no issue for the `Slider` component, though, which also lacks a focus state.
- Your icons are not accessible since they do not label the `svg`s correctly. But that’s probably an issue for the `radix-icons` repository?

Happy to open separate issues for those.

## Directly in the primitives

- The inputs/textareas are not using (or enforcing the use of) `label` elements. You should probably add a visually hidden label to those controls by default. The `placeholder` attribute is [not](https://www.smashingmagazine.com/2018/06/placeholder-attribute/#interoperability) [good](https://www.nngroup.com/articles/form-design-placeholders/) [enough](https://www.deque.com/blog/accessible-forms-the-problem-with-placeholders/). If you decide to keep using `placeholder`, you could start by improving its color contrast so that it passes the WCAG contrast ratio check.
- The checkboxes, sliders and switches don’t use `label` elements either (or don’t link their `p` label using `aria-labelledby`), which actually leads to UX issues like the fact that clicking the label of the checkboxes doesn’t toggle the checkbox.
- The `disabled` attribute is used for buttons/inputs but it leads to them being undiscoverable since those are not focusable, which could lead to screen-reader users getting confused. 😞The solution here would be to output `aria-disabled="true"` instead, style them yourself and make sure all mouse and keyboard events are ignored.

I’m guessing the same primitives are also used in Modulz projects? Do you think accessibility should be handled in user-land, which I guess also gives users more flexibility on the DOM structure? IMO if it could be enforced directly through the primitives it’d be awesome, but you probably have given more thought to this than I did. 😅
I also would have loved to contribute to the primitives, hope you’ll make them open-source at some point!