### PR TITLE
Add Subheading component

### DIFF
--- a/packages/radix/src/components/Subheading.story.tsx
+++ b/packages/radix/src/components/Subheading.story.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Box } from './Box';
+import { Subheading } from './Subheading';
+
+storiesOf('Components|Subheading', module).add('default', () => (
+  <>
+    <Box mb={6}>
+      <Subheading as="p" size={0}>
+        The visual code editor
+      </Subheading>
+    </Box>
+
+    <Box mb={6}>
+      <Subheading as="p" size={1}>
+        The visual code editor
+      </Subheading>
+    </Box>
+  </>
+));

--- a/packages/radix/src/components/Subheading.tsx
+++ b/packages/radix/src/components/Subheading.tsx
@@ -26,7 +26,7 @@ export const Subheading = React.forwardRef<HTMLHeadingElement, SubheadingProps>(
               letterSpacing: '0.035em',
               lineHeight: theme.lineHeights[1],
 
-              // Chrome won't use the caps kerning data otherwise
+              // Chrome doesn't use kerning on the faux small caps otherwise
               textTransform: 'uppercase',
             },
           },

--- a/packages/radix/src/components/Subheading.tsx
+++ b/packages/radix/src/components/Subheading.tsx
@@ -19,12 +19,10 @@ export const Subheading = React.forwardRef<HTMLHeadingElement, SubheadingProps>(
           text: {
             normal: {
               fontFamily: theme.fonts.normal,
-              fontSize: theme.fontSizes[3],
               fontVariant: 'all-small-caps',
               fontWeight: 500,
               color: theme.colors.gray800,
               letterSpacing: '0.035em',
-              lineHeight: theme.lineHeights[1],
 
               // Chrome doesn't use kerning on the faux small caps otherwise
               textTransform: 'uppercase',

--- a/packages/radix/src/components/Subheading.tsx
+++ b/packages/radix/src/components/Subheading.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Text as TextPrimitive, TextProps as TextPrimitiveProps } from '@modulz/primitives';
+import { theme } from '../theme';
+
+type Size = 0 | 1;
+
+export type SubheadingProps = TextPrimitiveProps & {
+  size?: Size;
+  truncate?: boolean;
+};
+
+export const Subheading = React.forwardRef<HTMLHeadingElement, SubheadingProps>(
+  (props, forwardedRef) => (
+    <TextPrimitive
+      {...props}
+      ref={forwardedRef}
+      styleConfig={{
+        base: {
+          text: {
+            normal: {
+              fontFamily: theme.fonts.normal,
+              fontSize: theme.fontSizes[3],
+              fontVariant: 'all-small-caps',
+              fontWeight: 500,
+              color: theme.colors.gray800,
+              letterSpacing: '0.035em',
+              lineHeight: theme.lineHeights[1],
+
+              // Chrome won't use the caps kerning data otherwise
+              textTransform: 'uppercase',
+            },
+          },
+        },
+        variants: {
+          size: {
+            0: {
+              text: {
+                normal: {
+                  fontSize: theme.fontSizes[3],
+                  lineHeight: theme.lineHeights[1],
+                },
+              },
+            },
+            1: {
+              text: {
+                normal: {
+                  fontSize: theme.fontSizes[5],
+                  lineHeight: theme.lineHeights[1],
+                },
+              },
+            },
+          },
+          truncate: {
+            true: {
+              text: {
+                normal: {
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                  overflow: 'hidden',
+                },
+              },
+            },
+          },
+        },
+      }}
+    />
+  )
+);
+
+Subheading.defaultProps = {
+  as: 'h2',
+  size: 0,
+  truncate: false,
+};

--- a/packages/radix/src/index.ts
+++ b/packages/radix/src/index.ts
@@ -64,6 +64,7 @@ export {
   OptionGroupProps,
 } from './components/Select';
 export { Slider, SliderProps } from './components/Slider';
+export { Subheading, SubheadingProps } from './components/Subheading';
 export { Switch, SwitchProps } from './components/Switch';
 export {
   Table,

--- a/packages/website/src/docs/chromeless-button.mdx
+++ b/packages/website/src/docs/chromeless-button.mdx
@@ -1,7 +1,7 @@
 ---
-title: ChromelessButton
+title: Chromeless Button
 component: ChromelessButton
-description: Useful to use as a base for custom Buttons.
+description: Useful as a base for custom buttons.
 ---
 
 ```js live

--- a/packages/website/src/docs/menu.mdx
+++ b/packages/website/src/docs/menu.mdx
@@ -1,7 +1,7 @@
 ---
 title: Menu
 component: Menu
-description: Useful for displaying a list of actions. Typically not used directly but in conjunction with other components like RightClickMenu or DropdownMenu.
+description: Useful for displaying a list of actions. Typically not used directly but in conjunction with other components like Right Click Menu or Dropdown Menu.
 disableLock: true
 ---
 

--- a/packages/website/src/docs/subheading.mdx
+++ b/packages/website/src/docs/subheading.mdx
@@ -1,0 +1,49 @@
+---
+title: Subheading
+component: Subheading
+description: Useful for rendering section headings.
+---
+
+```js live
+<Subheading>Subheading component</Subheading>
+```
+
+<PropsTable
+  data={{
+    children: {
+      type: 'ReactNode',
+      description: 'The content to render',
+    },
+    size: {
+      type: '0 | 1',
+      default: '0',
+      description: 'The size to apply',
+    },
+    truncate: {
+      type: 'Boolean',
+      default: 'false',
+      description: 'Whether it should truncate or not',
+    },
+  }}
+/>
+
+## Examples
+
+### Size
+
+There are 2 sizes to choose from.
+
+```js live
+<Subheading size={0}>Subheading component</Subheading>
+<Subheading size={1} mt={1}>Subheading component</Subheading>
+```
+
+### Text truncation
+
+When `true` this will truncate your text based on its maximum width.
+
+```js live
+<Box sx={{ width: 100 }}>
+  <Subheading truncate>Subheading component</Subheading>
+</Box>
+```


### PR DESCRIPTION
Adding a Subheading component to use for section headings in the Editor and in the marketing blog.

<img width="1120" alt="Screenshot 2020-04-13 at 15 12 08" src="https://user-images.githubusercontent.com/8441036/79120274-302ed580-7d9b-11ea-99ac-14d925c49317.png">

***
<img width="250" alt="Screenshot 2020-04-13 at 15 10 17" src="https://user-images.githubusercontent.com/8441036/79120288-32912f80-7d9b-11ea-9b1a-6978a77ef683.png">

