### PR TITLE
Avatar design update and more

### DIFF
--- a/packages/radix/package.json
+++ b/packages/radix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",
-    "@modulz/radix-icons": "2.0.0",
+    "@modulz/radix-icons": "2.1.0",
     "@storybook/addon-options": "5.2.8",
     "@storybook/addons": "5.2.8",
     "@storybook/react": "5.2.8",

--- a/packages/radix/src/components/Avatar.tsx
+++ b/packages/radix/src/components/Avatar.tsx
@@ -17,10 +17,9 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props, for
         avatar: {
           normal: {
             borderRadius: '100%',
-            backgroundColor: theme.colors.gray300,
+            backgroundColor: theme.colors.gray200,
             color: theme.colors.gray800,
             fontFamily: theme.fonts.normal,
-            fontWeight: 500,
             textTransform: 'uppercase',
           },
         },
@@ -30,7 +29,7 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props, for
           0: {
             avatar: {
               normal: {
-                fontSize: theme.fontSizes[1],
+                fontSize: theme.fontSizes[2],
                 lineHeight: theme.lineHeights[2],
                 width: theme.sizes[5],
                 height: theme.sizes[5],
@@ -40,7 +39,7 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props, for
           1: {
             avatar: {
               normal: {
-                fontSize: theme.fontSizes[3],
+                fontSize: theme.fontSizes[4],
                 lineHeight: theme.lineHeights[4],
                 width: theme.sizes[6],
                 height: theme.sizes[6],

--- a/packages/radix/src/components/Subheading.tsx
+++ b/packages/radix/src/components/Subheading.tsx
@@ -22,7 +22,7 @@ export const Subheading = React.forwardRef<HTMLHeadingElement, SubheadingProps>(
               fontVariant: 'all-small-caps',
               fontWeight: 500,
               color: theme.colors.gray800,
-              letterSpacing: '0.035em',
+              letterSpacing: '0.05em',
 
               // Chrome doesn't use kerning on the faux small caps otherwise
               textTransform: 'uppercase',

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -16,7 +16,7 @@
     "@mdx-js/react": "^1.5.5",
     "@modulz/primitives": "0.0.1-32",
     "@modulz/radix": "^0.0.1-beta.37",
-    "@modulz/radix-icons": "2.0.0",
+    "@modulz/radix-icons": "2.1.0",
     "@modulz/radix-system": "0.0.1-alpha.11",
     "babel-plugin-styled-components": "^1.10.7",
     "gatsby": "^2.19.17",

--- a/packages/website/src/App.js
+++ b/packages/website/src/App.js
@@ -1,18 +1,18 @@
 import React, { useState } from 'react';
-import { StaticQuery, graphql } from 'gatsby';
 import {
-  Flex,
-  Box,
-  List,
-  Heading,
   Badge,
-  Divider,
+  Box,
   Container,
+  Divider,
+  Flex,
   IconButton,
-  Text,
   Link,
+  List,
+  Subheading,
+  Text,
 } from '@modulz/radix';
-import { HamburgerIcon, CrossIcon } from '@modulz/radix-icons';
+import { CrossIcon, HamburgerIcon } from '@modulz/radix-icons';
+import { graphql, StaticQuery } from 'gatsby';
 import NavItem from './components/NavItem';
 import pkg from '../package.json';
 
@@ -120,9 +120,9 @@ function App({ element, props }) {
               <Box sx={{ display: [navOpen ? 'block' : 'none', 'block'] }}>
                 <Divider mb={1} />
                 <List>
-                  <Heading size={0} my={2} mx={5}>
+                  <Subheading mx={5} my={2}>
                     Overview
-                  </Heading>
+                  </Subheading>
                   {data.pinned.edges.map(({ node }) => (
                     <NavItem
                       key={node.frontmatter.title}
@@ -138,9 +138,9 @@ function App({ element, props }) {
                 <Divider mb={1} />
 
                 <List>
-                  <Heading size={0} my={2} mx={5}>
+                  <Subheading mx={5} my={2}>
                     Components
-                  </Heading>
+                  </Subheading>
                   {data.components.edges.map(({ node }) => (
                     <NavItem
                       key={node.frontmatter.title}
@@ -156,9 +156,9 @@ function App({ element, props }) {
                 <Divider mb={1} />
 
                 {/* <List>
-                  <Heading size={0}  mx={5} mb={2} mt={2}>
+                  <Subheading mx={5} my={2}>
                     Recipes
-                  </Heading>
+                  </Subheading>
                   {data.recipes.edges.map(({ node }) => (
                     <NavItem
                       key={node.frontmatter.title}
@@ -174,9 +174,9 @@ function App({ element, props }) {
                 <Divider mb={1} /> */}
 
                 <List>
-                  <Heading size={0} mx={5} mb={2} mt={2}>
-                    Github links
-                  </Heading>
+                  <Subheading mx={5} my={2}>
+                    GitHub links
+                  </Subheading>
 
                   <NavItem as="a" href="https://github.com/modulz/radix" isExternal>
                     Radix

--- a/packages/website/src/components/NavItem.js
+++ b/packages/website/src/components/NavItem.js
@@ -8,6 +8,7 @@ function NavItem({ children, isExternal, active, ...props }) {
     <ListItem
       as={Link}
       {...props}
+      target={isExternal ? '_blank' : undefined}
       variant={active ? 'active' : undefined}
       px={5}
       sx={{ minHeight: 6 }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,6 +1960,11 @@
   resolved "https://registry.yarnpkg.com/@modulz/radix-icons/-/radix-icons-2.0.0.tgz#b179f0328b10d82573b77f2e22825d8647d7033b"
   integrity sha512-kp7hVMPVaQ2+9r2l6Cg28Huj5z3aBKl1jk7lmqtnnPEJH7vr6p6lS3u2RxMhTGQvg+H1mXJGTKhveG++87RYGQ==
 
+"@modulz/radix-icons@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@modulz/radix-icons/-/radix-icons-2.1.0.tgz#214142d956a1bf88326ade7b7ae628fedf5d6dad"
+  integrity sha512-eTSt5odB+n52LG8GFRNbJLSjKIf9Q/gUa61Nch/TQQKjU27Txxjo4eEilhvL/R1/FYyHjslyMJaKQ2IHLnrUBg==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
- Updated Avatar design. Using lighter weight, larger font size, lighter background. Closes #244. 
- Changed Subheading letter spacing `0.035em` → `0.05em`
- Changed docs navigation to use the Subheading
- Changed docs links with External Link Icon to open in new tab
- Updated Radix Icons version to latest. Still need to bump up Radix Icons in Primitives.
