### PR TITLE
Avatar design update and a black variant

### DIFF
--- a/packages/radix/src/components/Avatar.story.tsx
+++ b/packages/radix/src/components/Avatar.story.tsx
@@ -6,21 +6,31 @@ import { Avatar } from './Avatar';
 
 storiesOf('Components|Avatar', module).add('default', () => (
   <>
-    <Flex>
-      <Box m={2}>
-        <Avatar>AV</Avatar>
-      </Box>
-      <Box m={2}>
-        <Avatar alt="Modulz" src="https://avatars0.githubusercontent.com/u/28682402" />
-      </Box>
-    </Flex>
-    <Flex>
-      <Box m={2}>
-        <Avatar size={1}>AV</Avatar>
-      </Box>
-      <Box m={2}>
-        <Avatar size={1} alt="Modulz" src="https://avatars0.githubusercontent.com/u/28682402" />
-      </Box>
-    </Flex>
+    <Box>
+      <Flex>
+        <Box m={2}>
+          <Avatar>A</Avatar>
+        </Box>
+        <Box m={2}>
+          <Avatar variant="black">A</Avatar>
+        </Box>
+        <Box m={2}>
+          <Avatar alt="Modulz" src="https://avatars0.githubusercontent.com/u/28682402" />
+        </Box>
+      </Flex>
+      <Flex>
+        <Box m={2}>
+          <Avatar size={1}>A</Avatar>
+        </Box>
+        <Box m={2}>
+          <Avatar size={1} variant="black">
+            A
+          </Avatar>
+        </Box>
+        <Box m={2}>
+          <Avatar size={1} alt="Modulz" src="https://avatars0.githubusercontent.com/u/28682402" />
+        </Box>
+      </Flex>
+    </Box>
   </>
 ));

--- a/packages/radix/src/components/Avatar.tsx
+++ b/packages/radix/src/components/Avatar.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { Avatar as AvatarPrimitive, AvatarProps as AvatarPrimitiveProps } from '@modulz/primitives';
 import { theme } from '../theme';
 
+type Variant = 'gray' | 'black';
 type Size = 0 | 1;
 
 export type AvatarProps = AvatarPrimitiveProps & {
+  variant?: Variant;
   size?: Size;
 };
 
@@ -17,14 +19,30 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props, for
         avatar: {
           normal: {
             borderRadius: '100%',
-            backgroundColor: theme.colors.gray200,
-            color: theme.colors.gray800,
+            color: 'white',
             fontFamily: theme.fonts.normal,
+            fontWeight: 500,
             textTransform: 'uppercase',
           },
         },
       },
       variants: {
+        variant: {
+          gray: {
+            avatar: {
+              normal: {
+                backgroundImage: `linear-gradient(${theme.colors.gray600}, ${theme.colors.gray700})`,
+              },
+            },
+          },
+          black: {
+            avatar: {
+              normal: {
+                backgroundColor: theme.colors.gray800,
+              },
+            },
+          },
+        },
         size: {
           0: {
             avatar: {
@@ -39,7 +57,7 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props, for
           1: {
             avatar: {
               normal: {
-                fontSize: theme.fontSizes[4],
+                fontSize: theme.fontSizes[5],
                 lineHeight: theme.lineHeights[4],
                 width: theme.sizes[6],
                 height: theme.sizes[6],
@@ -53,5 +71,6 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props, for
 ));
 
 Avatar.defaultProps = {
+  variant: 'gray',
   size: 0,
 };

--- a/packages/website/src/docs/avatar.mdx
+++ b/packages/website/src/docs/avatar.mdx
@@ -27,6 +27,11 @@ description: Useful for presenting profile images and initials.
       type: 'string',
       description: 'The URL of the image to use',
     },
+    variant: {
+      type: 'gray | black',
+      default: 'gray',
+      description: 'The variant to apply',
+    },
     size: {
       type: '0 | 1',
       default: '0',
@@ -36,6 +41,20 @@ description: Useful for presenting profile images and initials.
 />
 
 ## Examples
+
+### Variants
+
+There are 2 variants to choose from.
+
+```js live
+<Avatar variant="gray" alt="Modulz">
+  M
+</Avatar>
+
+<Avatar variant="black" alt="Modulz" ml={4}>
+  M
+</Avatar>
+```
 
 ### Size
 


### PR DESCRIPTION
Yet another Avatar design update and a black (dark?) variant to use in Modulz for the default design system logos.

<img width="185" alt="Screenshot 2020-04-21 at 23 42 03" src="https://user-images.githubusercontent.com/8441036/79911833-b7c6b500-8429-11ea-9979-ce864494f232.png">

The variants are named `variant="gray"` and `variant="black"`