### PR TITLE
Fix the input baseline position

### DIFF
--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -86,16 +86,16 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 // text look not centered vertically within the input.
                 //
                 // This happens because actual input text is rendered by a shadow DOM element, which doesn't use
-                // the input's line height. Instead, it uses the default "line-height: normal", which means 1.2.
+                // the line height of the input. Instead, it uses the default "line-height: normal", which means 1.2.
                 //
                 // So:
                 // * The input height is 35px, the font size is 13px
                 // * The shadow DOM element height is Math.ceil(13px * 1.2) = 16px
                 // * 35px - 16px = 19px for the browser to allocate above and below the shadow DOM element
                 //
-                // Hence the 1px padding to resolve the mismatch between the odd input height (35px) and the even
-                // shadow DOM value element height (16px). This way baseline position stays consistent no matter
-                // how the input is placed.
+                // Hence adding the 1px padding to resolve the mismatch between the odd input height (35px) and
+                // the even shadow DOM value element height (16px). This way baseline position stays consistent
+                // no matter how the input is placed.
                 paddingBottom: '1px',
               },
             },

--- a/packages/radix/src/components/Input.tsx
+++ b/packages/radix/src/components/Input.tsx
@@ -76,6 +76,27 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
                 lineHeight: theme.lineHeights[0], // Yields nice text selection height in Safari
                 paddingLeft: theme.space[2],
                 paddingRight: theme.space[2],
+
+                // A workaround for a tiny visual bug in Chrome
+                //
+                // When input is positioned ambiguously — imagine it's vertically centered on the screen
+                // so its position seems to be calculated with subpixel-level precision — there is a schism
+                // between how the actual input “box” is placed and how its text baseline is placed. In this
+                // case resizing the viewport height may introduce slight baseline misalignments and make
+                // text look not centered vertically within the input.
+                //
+                // This happens because actual input text is rendered by a shadow DOM element, which doesn't use
+                // the input's line height. Instead, it uses the default "line-height: normal", which means 1.2.
+                //
+                // So:
+                // * The input height is 35px, the font size is 13px
+                // * The shadow DOM element height is Math.ceil(13px * 1.2) = 16px
+                // * 35px - 16px = 19px for the browser to allocate above and below the shadow DOM element
+                //
+                // Hence the 1px padding to resolve the mismatch between the odd input height (35px) and the even
+                // shadow DOM value element height (16px). This way baseline position stays consistent no matter
+                // how the input is placed.
+                paddingBottom: '1px',
               },
             },
           },


### PR DESCRIPTION
Adding a workaround for a tiny visual bug in Chrome.

Before:
<img src="https://user-images.githubusercontent.com/8441036/80184893-18194a80-8614-11ea-9081-f42ec69f9e5b.gif" height="200" />

After:
<img src="https://user-images.githubusercontent.com/8441036/80184941-2d8e7480-8614-11ea-9cc4-70529555534e.gif" height="200" />

When input is positioned ambiguously — imagine it's vertically centered on the screen so its position seems to be calculated with subpixel-level precision — there is a schism between how the actual input “box” is placed and how its text baseline is placed. In this case resizing the viewport height may introduce slight baseline misalignments and make text look not centered vertically within the input.

This happens because actual input text is rendered by a shadow DOM element, which doesn't use the line height of the input. Instead, it uses the default `line-height: normal`, which means `1.2`.

<img width="590" alt="Screenshot 2020-04-24 at 10 25 34" src="https://user-images.githubusercontent.com/8441036/80185980-f325d700-8615-11ea-9f91-951c628e8971.png">

So:
* The input height is 35, the font size is 13
* The shadow DOM element height is Math.ceil(13 * 1.2) = 16
* 35 - 16 = 19 pixels for the browser to allocate above and below the shadow DOM element

Hence adding the 1px padding to resolve the mismatch between the odd input height (35px) and the even shadow DOM value element height (16px). This way baseline position stays consistent no matter how the input is placed.