### PR TITLE
Optically-centered dialog

### DIFF
--- a/packages/radix/src/components/Dialog.tsx
+++ b/packages/radix/src/components/Dialog.tsx
@@ -30,7 +30,7 @@ export const Dialog = (props: DialogProps) => (
             width: 'auto',
             maxWidth: 'fit-content',
             minWidth: 200,
-            maxHeight: '90vh',
+            maxHeight: '85vh',
             margin: '5vh auto 10vh',
             overflow: 'auto',
           },

--- a/packages/radix/src/components/Dialog.tsx
+++ b/packages/radix/src/components/Dialog.tsx
@@ -31,7 +31,7 @@ export const Dialog = (props: DialogProps) => (
             maxWidth: 'fit-content',
             minWidth: 200,
             maxHeight: '90vh',
-            margin: '5vh auto',
+            margin: '5vh auto 10vh',
             overflow: 'auto',
           },
         },


### PR DESCRIPTION
Adding a slight optical compensation to the dialog margin so it _feels_ centered vertically, since perfect vertical centering makes the dialog look lower than it really is.

Optical centering:

<img width="2137" alt="Screenshot 2020-04-24 at 11 06 12" src="https://user-images.githubusercontent.com/8441036/80190235-a1cd1600-861c-11ea-9e22-e546779fbd6d.png">

Perfect centering:

<img width="2137" alt="Screenshot 2020-04-24 at 11 06 00" src="https://user-images.githubusercontent.com/8441036/80190243-a691ca00-861c-11ea-84a1-7c31a1ade82b.png">