### PR TITLE
fix(PropsTable): cell white space wrapping

### DIFF
--- a/packages/website/src/components/PropsTable.js
+++ b/packages/website/src/components/PropsTable.js
@@ -45,7 +45,7 @@ export function PropsTable({ data = {} }) {
                       <Code>{key}</Code>
                     </Td>
                     <Td>
-                      <Code sx={{ whiteSpace: 'nowrap' }}>{value.type}</Code>
+                      <Code>{value.type}</Code>
                     </Td>
                     <Td sx={{ lineHeight: 1 }}>{value.description}</Td>
                   </Tr>


### PR DESCRIPTION
I may be in the wrong here, but I think this does not look ideal 🙈

<img width="1792" alt="Screenshot 2020-05-19 at 18 30 23" src="https://user-images.githubusercontent.com/23662329/82346185-d30fea80-99fe-11ea-89d6-1496fd57074e.png">

I think it should be fine to wrap here in all cases, but if not, feel free to close this 🙃